### PR TITLE
Restore the helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,4 +205,4 @@ misspell:
 		-i clas \
 		-locale US \
 		-error \
-		cmd/* pkg/* docs/* *.md
+		cmd/* pkg/* docs/* chart/*.md *.md

--- a/README.md
+++ b/README.md
@@ -10,20 +10,27 @@ requests route through Cloudflare before reaching the web server so you can be
 sure attack traffic is stopped with Cloudflare’s WAF and Unmetered DDoS mitigation
 and authenticated with Access if you’ve enabled those features for your account.
 
-- [Argo Smart Routing][agro-smart-routing]
+- [Argo Smart Routing][argo-smart-routing]
 - [Argo Tunnel][argo-tunnel-quick-start]
 
 ### Deploy
 ```bash
 kubectl apply -f deploy/argo-tunnel.yaml
 ```
+> Update the `ServiceAccount` namespace and bindings to deploy in an alternate namespace.
+
+Without role based access control (RBAC).
+```bash
+kubectl apply -f deploy/argo-tunnel-no-rbac.yaml
+```
 
 ### Guides & Reference
 - [Argo Tunnel: Reference][argo-tunnel-reference]
 - [Argo Tunnel: Quick Start][argo-tunnel-quick-start]
+- [Deploying with Helm][guide-helm-deploy]
 - [Setup Your First Tunnel][guide-first-tunnel]
-- [Setup High Availability with Load Balancers][guide-ha-tunnel]
 - [Setup Tunnels to Subdomains][guide-subdomain-tunnel]
+- [Setup High Availability with Load Balancers][guide-ha-tunnel]
 - [Supported Command-Line Options, Annotations & Labels][controls]
 - [Monitoring & Analytics][observability]
 
@@ -38,7 +45,7 @@ Thanks in advance for any and all contributions!
 The [Cloudflare community forum][cloudflare-community] is a place to discuss
 Argo, Argo Tunnel, or any Cloudflare product.
 
-[agro-smart-routing]: https://www.cloudflare.com/products/argo-smart-routing/
+[argo-smart-routing]: https://www.cloudflare.com/products/argo-smart-routing/
 [argo-tunnel-reference]: https://developers.cloudflare.com/argo-tunnel/reference/
 [argo-tunnel-quick-start]: https://developers.cloudflare.com/argo-tunnel/quickstart/
 [cloudflare-community]: https://community.cloudflare.com
@@ -47,6 +54,7 @@ Argo, Argo Tunnel, or any Cloudflare product.
 [controls]: /docs/controls.md
 [guide-first-tunnel]: /docs/guide_first_tunnel.md
 [guide-ha-tunnel]: /docs/guide_ha_tunnel.md
+[guide-helm-deploy]: /chart/README.md
 [guide-subdomain-tunnel]: /docs/guide_subdomain_tunnel.md
 [issues]: https://github.com/cloudflare/cloudflare-ingress-controller/issues
 [observability]: /docs/observability.md

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: argo-tunnel
+version: 0.5.2
+home: https://developers.cloudflare.com/argo-tunnel/
+description: Installs the cloudflare argo tunnel ingress controller
+maintainers:
+  - name: Nathan Franzen
+    email: nate@stackpointcloud.com

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,69 @@
+# Argo Tunnel Ingress Controller
+
+### TL;DR;
+```console
+$ helm install --name argo-mydomain chart/
+```
+> **Tip**: See [Your First Tunnel][guide-first-tunnel].
+
+### About
+Argo Tunnel Ingress Controller provides Kubernetes Ingress via Argo Tunnels.
+The controller establishes or destroys tunnels by monitoring changes to resources.
+
+Argo Tunnel offers an easy way to expose web servers securely to the internet,
+without opening up firewall ports and configuring ACLs. Argo Tunnel also ensures
+requests route through Cloudflare before reaching the web server so you can be 
+sure attack traffic is stopped with Cloudflare’s WAF and Unmetered DDoS mitigation
+and authenticated with Access if you’ve enabled those features for your account.
+
+- [Argo Smart Routing][argo-smart-routing]
+- [Argo Tunnel: Reference][argo-tunnel-reference]
+- [Argo Tunnel: Quick Start][argo-tunnel-quick-start]
+- [Argo Tunnel Ingress: Quick Start][argo-tunnel-ingress-quick-start]
+
+### Installing the Chart
+To install the chart with the release name `argo-mydomain`:
+```console
+$ helm install --name argo-mydomain chart/
+```
+> **Tip**: See [Your First Tunnel][guide-first-tunnel].
+
+The command deploys the controller on the Kubernetes cluster in the default configuration.
+The [configuration](#configuration) section lists the parameters that can be configured
+during installation.
+
+> **Tip**: List all releases using `helm list`
+
+### Uninstalling the Chart
+To uninstall/delete the `argo-mydomain` deployment:
+```console
+$ helm delete argo-mydomain
+```
+
+### Configuration
+The following table lists the configurable parameters of the chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`controller.name` | name of the controller component | `controller`
+`controller.image.repository` | controller container image repository | `gcr.io/stackpoint-public/argot`
+`controller.image.tag` | controller container image tag | `0.5.2`
+`controller.image.pullPolicy` | controller container image pull policy | `Always`
+`controller.ingressClass` | name of the ingress class to route through this controller | `argo-tunnel`
+`controller.logLevel` | log-level for this controller | `2`
+`controller.replicaCount` | desired number of controller pods | `1`
+`loadBalancing.enabled` | if `true`, replicaCount may be >1, requires load balancing enabled on account | `false`
+`rbac.create` | if `true`, create & use RBAC resources | `true`
+`serviceAccount.create` | if `true`, create a service account | ``
+`serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
+
+A useful trick to debug issues with ingress is to increase the logLevel.
+```console
+$ helm install chart/ --set controller.logLevel=6
+```
+
+[argo-smart-routing]: https://www.cloudflare.com/products/argo-smart-routing/
+[argo-tunnel-reference]: https://developers.cloudflare.com/argo-tunnel/reference/
+[argo-tunnel-quick-start]: https://developers.cloudflare.com/argo-tunnel/quickstart/
+[argo-tunnel-ingress-quick-start]: https://github.com/cloudflare/cloudflare-ingress-controller/
+[guide-first-tunnel]: ../docs/guide_first_tunnel.md

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,33 @@
+The Cloudflare Argo Tunnel Ingress Controller has been installed.
+
+The ingress controller requires domain credentials to create Argo Tunnels.
+Obtain the credentials for your cloudflare domain using the _cloudflared_ binary.
+ - See https://developers.cloudflare.com/argo-tunnel/quickstart/
+
+ Create and label the secret. The name of the secret does NOT matter.
+ The secret MUST be labeled with the associated cloudflare domain.
+
+ kubectl -n={{ .Release.Namespace }} \
+    create secret generic mydomain-tunnel-cert \
+    --from-file=cert.pem="$HOME/.cloudflared/cert.pem"
+
+kubectl -n={{ .Release.Namespace }} \
+     label secret mydomain-tunnel-cert \
+     "cloudflare-argo/domain=mydomain.com"
+
+{{ if .Values.loadBalancing.enabled }}
+Load balancing has been enabled for the deployment.
+Loab balancing MUST also be enabled for the cloudflare account.
+
+To use a load balancer, annotate the ingress with `argo.cloudflare.com/lb-pool`
+matching a named loadbalancer defined in the cloudflare dashboard.
+ - See https://www.cloudflare.com/a/traffic/
+
+kubectl annotate ingress mydomain-tunnel \
+     "argo.cloudflare.com/lb-pool=mydomain-lb-pool"
+{{- end }}
+
+References
+ - Reference: https://developers.cloudflare.com/argo-tunnel/reference/ 
+ - QuickStart: https://developers.cloudflare.com/argo-tunnel/quickstart/
+ - Dashboard: https://www.cloudflare.com/a/traffic/

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argo-tunnel.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "argo-tunnel.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" $name .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the role to use
+*/}}
+{{- define "argo-tunnel.roleName" -}}
+{{- if .Values.rbac.create -}}
+    {{ default (include "argo-tunnel.fullname" .) .Values.rbac.name }}
+{{- else -}}
+    {{ default "default" .Values.rbac.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "argo-tunnel.serviceAccountName" -}}
+{{- if or .Values.serviceAccount.create .Values.rbac.create -}}
+    {{ default (include "argo-tunnel.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "argo-tunnel.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "argo-tunnel.roleName" . }}
+rules:
+- apiGroups:
+  - ""
+  - "extensions"
+  resources:
+  - endpoints
+  - services
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - update
+{{- end }}

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "argo-tunnel.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "argo-tunnel.roleName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "argo-tunnel.roleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "argo-tunnel.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "argo-tunnel.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "argo-tunnel.fullname" . }}
+spec:
+  {{- if .Values.loadBalancing.enabled }}
+  replicas: {{ .Values.controller.replicaCount }}
+  {{- else }}
+  replicas: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "argo-tunnel.name" . }}
+      component: {{ .Values.controller.name }}
+      release: {{ .Release.Name }}
+strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ template "argo-tunnel.name" . }}
+        component: {{ .Values.controller.name }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ template "argo-tunnel.name" . }}-{{ .Values.controller.name }}
+        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+        command: ["/argot"]
+        args:
+        - --v={{ .Values.controller.logLevel }}
+        - --ingressClass={{ .Values.controller.ingressClass }}
+        - --namespace=$(POD_NAMESPACE)
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      {{- if or .Values.serviceAccount.create .Values.rbac.create }}
+      serviceAccount: {{ template "argo-tunnel.serviceAccountName" . }}
+      serviceAccountName: {{ template "argo-tunnel.serviceAccountName" . }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: {{ template "argo-tunnel.name" . }}
+                  component: {{ .Values.controller.name }}
+                  release: {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "argo-tunnel.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "argo-tunnel.roleName" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+{{- end }}

--- a/chart/templates/rolebinding.yaml
+++ b/chart/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "argo-tunnel.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "argo-tunnel.roleName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "argo-tunnel.roleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "argo-tunnel.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if or .Values.serviceAccount.create .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "argo-tunnel.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "argo-tunnel.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,24 @@
+# Default values for cloudflare argo-tunnel ingress.
+controller:
+  name: controller
+  image:
+    repository: gcr.io/stackpoint-public/argot
+    tag: "0.5.2"
+    pullPolicy: Always
+  ingressClass: argo-tunnel
+  logLevel: 2
+  replicaCount: 1
+
+# Enable load balancing
+# requires load balancing enabled on the cloudflare account.
+loadBalancing:
+  enabled: false
+
+# Enable rbac
+rbac:
+  create: true
+  name:
+
+serviceAccount:
+  create: true
+  name:

--- a/deploy/argo-tunnel-no-rbac.yaml
+++ b/deploy/argo-tunnel-no-rbac.yaml
@@ -1,0 +1,50 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: argo-tunnel
+  name: argo-tunnel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: argo-tunnel
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: argo-tunnel
+    spec:
+      containers:
+      - image: gcr.io/stackpoint-public/argot:0.5.2
+        imagePullPolicy: Always
+        name: argo-tunnel
+        command: ["/argot"]
+        args:
+        - --v=2
+        - --ingressClass=argo-tunnel
+        - --namespace=$(POD_NAMESPACE)
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: argo-tunnel
+              topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
This restores the helm chart deleted with #45 and updates the
documentation for the chart to provide configuration details. It does
not restore secret installation from the helm chart.

fixes #7