### PR TITLE
Correct YAML indenting

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       app: {{ template "argo-tunnel.name" . }}
       component: {{ .Values.controller.name }}
       release: {{ .Release.Name }}
-strategy:
+  strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1


### PR DESCRIPTION
Fixes the error
```
Error: YAML parse error on argo-tunnel/templates/deployment.yaml: error converting YAML to JSON: yaml: line 21: did not find expected key
```