### PR TITLE
Add -extldflags -static and -tags netgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY cmd cmd
 COPY internal internal
 RUN GO_EXTLINK_ENABLED=0 CGO_ENABLED=0 GOOS=linux go build \
     -o /go/bin/argot \
-    -ldflags="-w -extldflags -s -X github.com/cloudflare/cloudflare-ingress-controller/internal/version.VERSION=${VERSION}" \
+    -ldflags="-w -s -extldflags -static -X github.com/cloudflare/cloudflare-ingress-controller/internal/version.VERSION=${VERSION}" \
+    -tags netgo -installsuffix netgo \
     -v github.com/cloudflare/cloudflare-ingress-controller/cmd/argot
 
 FROM alpine:3.8 AS final

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -9,7 +9,8 @@ COPY cmd cmd
 COPY internal internal
 RUN GO_EXTLINK_ENABLED=0 CGO_ENABLED=0 GOOS=ARG_OS GOARCH=ARG_ARCH GOARM=ARG_ARM go build \
     -o /go/bin/argot \
-    -ldflags="-w -s -X github.com/cloudflare/cloudflare-ingress-controller/internal/version.VERSION=ARG_VERSION" \
+    -ldflags="-w -s -extldflags -static -X github.com/cloudflare/cloudflare-ingress-controller/internal/version.VERSION=ARG_VERSION" \
+    -tags netgo -installsuffix netgo \
     -v github.com/cloudflare/cloudflare-ingress-controller/cmd/argot
 
 FROM ARG_ROOT/alpine:3.8 AS final


### PR DESCRIPTION
Add -extldflags -static to -ldflags and -tags netgo to build command to
increase likelyhood of a fully static binary.

fixes #56