### PR TITLE
Replace config struct  with option pattern

### DIFF
--- a/cmd/argot/main.go
+++ b/cmd/argot/main.go
@@ -21,12 +21,8 @@ func main() {
 
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig file")
 	printVersion := flag.Bool("version", false, "prints application version")
-
-	config := &controller.Config{
-		MaxRetries: controller.MaxRetries,
-	}
-	flag.StringVar(&config.Namespace, "namespace", "default", "Namespace to run in")
-	flag.StringVar(&config.IngressClass, "ingressClass", controller.CloudflareArgoIngressType, "Name of ingress class, used in ingress annotation")
+	namespace := flag.String("namespace", controller.SecretNamespaceDefault, "Namespace to run in")
+	ingressClass := flag.String("ingressClass", controller.SecretNameDefault, "Name of ingress class, used in ingress annotation")
 
 	flag.Set("logtostderr", "true")
 	flag.Parse()
@@ -61,7 +57,10 @@ func main() {
 	}
 	{
 		ctx, cancel := context.WithCancel(context.Background())
-		argo := controller.NewArgoController(kclient, config)
+		argo := controller.NewArgoController(kclient,
+			controller.IngressClass(*ingressClass),
+			controller.SecretNamespace(*namespace),
+		)
 		argo.EnableMetrics()
 
 		g.Add(func() error {

--- a/internal/controller/const.go
+++ b/internal/controller/const.go
@@ -1,8 +1,5 @@
 package controller
 
 const (
-	MaxRetries                = 5
-	SecretLabelDomain         = "cloudflare-argo/domain"
-	SecretName                = "cloudflared-cert"
-	CloudflareArgoIngressType = "argo-tunnel"
+	SecretLabelDomain = "cloudflare-argo/domain"
 )

--- a/internal/controller/options.go
+++ b/internal/controller/options.go
@@ -1,0 +1,62 @@
+package controller
+
+const (
+	// IngressClassDefault defines the default class of ingresses managed by the controller
+	IngressClassDefault = "argo-tunnel"
+
+	// SecretNamespaceDefault defines the default namespace use to house tunnel secrets
+	// TODO: secrets should not be centally housed
+	// In multi-tentant environments, all tenants should be able to add secrets and define
+	// tunnels without access to a shared namespace.
+	SecretNamespaceDefault = "default"
+
+	// SecretNameDefault defines the default name for the default tunnel secret
+	// TODO: the concept of a hardcoded default secret name should be deprecated
+	// with the secret namespace, preferring a simple option to define a default
+	// tunnel secret by "namespace/name"
+	SecretNameDefault = "cloudflared-cert"
+)
+
+type options struct {
+	ingressClass    string
+	secretNamespace string
+	secretName      string
+}
+
+// Option provides behavior overrides
+type Option func(*options)
+
+// IngressClass defines the ingress class for the controller
+func IngressClass(s string) Option {
+	return func(o *options) {
+		o.ingressClass = s
+	}
+}
+
+// SecretName defines the namespace used to house tunnel secrets
+func SecretName(s string) Option {
+	return func(o *options) {
+		o.secretName = s
+	}
+}
+
+// SecretNamespace defines the namespace used to house tunnel secrets
+func SecretNamespace(s string) Option {
+	return func(o *options) {
+		o.secretNamespace = s
+	}
+}
+
+func collectOptions(opts []Option) options {
+	// set option defaults
+	o := options{
+		ingressClass:    IngressClassDefault,
+		secretNamespace: SecretNamespaceDefault,
+		secretName:      SecretNameDefault,
+	}
+	// overlay option values
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}

--- a/internal/controller/options_test.go
+++ b/internal/controller/options_test.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptions(t *testing.T) {
+	for name, test := range map[string]struct {
+		in  []Option
+		out options
+	}{
+		"default-options": {
+			in: []Option{},
+			out: options{
+				ingressClass:    IngressClassDefault,
+				secretName:      SecretNameDefault,
+				secretNamespace: SecretNamespaceDefault,
+			},
+		},
+		"set-one-option": {
+			in: []Option{
+				IngressClass("test-class"),
+			},
+			out: options{
+				ingressClass:    "test-class",
+				secretName:      SecretNameDefault,
+				secretNamespace: SecretNamespaceDefault,
+			},
+		},
+		"set-all-options": {
+			in: []Option{
+				IngressClass("test-class"),
+				SecretName("test-secret-name"),
+				SecretNamespace("test-secret-namespace"),
+			},
+			out: options{
+				ingressClass:    "test-class",
+				secretName:      "test-secret-name",
+				secretNamespace: "test-secret-namespace",
+			},
+		},
+	} {
+		out := collectOptions(test.in)
+		assert.Equalf(t, test.out, out, "test '%s' options mismatch", name)
+	}
+}


### PR DESCRIPTION
Remove the config struct and replace it with an option pattern.  This
allows configuration to be both less exposed (doesn't need to be
exported) and partial (only provide the options that are changing,
rather than the entire struct).  The base mechanism will be expanded,
allowing greater control (from either flags or annotations).