### PR TITLE
Separate annotations and provide consistent parsing

### DIFF
--- a/internal/controller/annotations.go
+++ b/internal/controller/annotations.go
@@ -1,0 +1,25 @@
+package controller
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+const (
+	annotationIngressClass        = "kubernetes.io/ingress.class"
+	annotationIngressLoadBalancer = "argo.cloudflare.com/lb-pool"
+)
+
+func parseIngressClass(ing *v1beta1.Ingress) (val string, ok bool) {
+	if ingMeta, err := meta.Accessor(ing); err == nil {
+		val, ok = ingMeta.GetAnnotations()[annotationIngressClass]
+	}
+	return
+}
+
+func parseIngressLoadBalancer(ing *v1beta1.Ingress) (val string, ok bool) {
+	if ingMeta, err := meta.Accessor(ing); err == nil {
+		val, ok = ingMeta.GetAnnotations()[annotationIngressLoadBalancer]
+	}
+	return
+}

--- a/internal/controller/annotations_test.go
+++ b/internal/controller/annotations_test.go
@@ -1,0 +1,106 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIngressClassAnnotation(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *v1beta1.Ingress
+		out string
+	}{
+		"empty-ingress": {
+			in:  &v1beta1.Ingress{},
+			out: "",
+		},
+		"without-ingress-class": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						annotationIngressClass + "-without": "test",
+					},
+				},
+			},
+			out: "",
+		},
+		"with-ingress-class": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						annotationIngressClass: "test",
+					},
+				},
+			},
+			out: "test",
+		},
+	} {
+		out, _ := parseIngressClass(test.in)
+		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+	}
+}
+
+func TestIngressLoadBalancerAnnotation(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *v1beta1.Ingress
+		out string
+	}{
+		"empty-ingress": {
+			in:  &v1beta1.Ingress{},
+			out: "",
+		},
+		"without-ingress-lb-pool": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						annotationIngressLoadBalancer + "-without": "test",
+					},
+				},
+			},
+			out: "",
+		},
+		"with-ingress-lb-pool": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						annotationIngressLoadBalancer: "test",
+					},
+				},
+			},
+			out: "test",
+		},
+	} {
+		out, _ := parseIngressLoadBalancer(test.in)
+		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+	}
+}

--- a/internal/controller/const.go
+++ b/internal/controller/const.go
@@ -2,8 +2,6 @@ package controller
 
 const (
 	MaxRetries                = 5
-	IngressClassKey           = "kubernetes.io/ingress.class"
-	IngressAnnotationLBPool   = "argo.cloudflare.com/lb-pool"
 	SecretLabelDomain         = "cloudflare-argo/domain"
 	SecretName                = "cloudflared-cert"
 	CloudflareArgoIngressType = "argo-tunnel"

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -264,7 +264,7 @@ func getTunnelItems(namespace string) tunnelItems {
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:        ingressName,
 			Namespace:   namespace,
-			Annotations: map[string]string{IngressAnnotationLBPool: poolName},
+			Annotations: map[string]string{annotationIngressLoadBalancer: poolName},
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{
@@ -287,7 +287,7 @@ func getTunnelItems(namespace string) tunnelItems {
 			},
 		},
 	}
-	meta_v1.SetMetaDataAnnotation(&ingress.ObjectMeta, IngressClassKey, CloudflareArgoIngressType)
+	meta_v1.SetMetaDataAnnotation(&ingress.ObjectMeta, annotationIngressClass, CloudflareArgoIngressType)
 
 	service := v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -322,11 +322,10 @@ func TestControllerLookups(t *testing.T) {
 
 	// broken for now
 	// assert.Equal(t, "fooservice", wc.getServiceNameForIngress(&items.Ingress))
-
+	lbpool, _ := parseIngressLoadBalancer(&items.Ingress)
 	assert.Equal(t, "test.example.com", wc.getHostNameForIngress(&items.Ingress))
 	assert.Equal(t, int32(80), wc.getServicePortForIngress(&items.Ingress).IntVal)
-
-	assert.Equal(t, "testpool", wc.getLBPoolForIngress(&items.Ingress))
+	assert.Equal(t, "testpool", lbpool)
 	// assert.Equal(t, "test.example.com", wc.getLBPoolForIngress(&items.Ingress))
 }
 


### PR DESCRIPTION
Move the annotations into a separate file with names that suggest they
are annotations.  This will help us quantify and expand annotation
support in the future.  Parsing functions are added that generically
consume objsand convert them to meta object accessors.  This object
conversion may be unnessecary; however, parsing the annotation for
ingress class was not consistent with the load balancer pool (object
sections obj.Annotations vs obj.ObjectMeta.Annotations respectively).