### PR TITLE
Resolves thread-safety issues on tunnel shutdown

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -406,9 +406,20 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:711eebe744c0151a9d09af2315f0bb729b2ec7637ef4c410fa90a18ef74b65b6"
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  pruneopts = ""
+  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
+  version = "v0.1.1"
+
+[[projects]]
   digest = "1:a30066593578732a356dc7e5d7f78d69184ca65aeeff5939241a3ab10559bb06"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "mock",
+  ]
   pruneopts = ""
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
@@ -716,8 +727,10 @@
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ push: container
 staticcheck:
 	@echo static checking code for issues
 	@go get honnef.co/go/tools/cmd/staticcheck
-	staticcheck $(SRCS)
+	@staticcheck $(SRCS)
 
 .PHONY: test
 test: install
@@ -130,13 +130,14 @@ test: install
 
 .PHONY: test-race
 test-race: | test
+	@echo testing code for races
 	@go test -race ./...
 
 .PHONY: unused
 unused:
 	@echo checking code for unused definitions
 	@go get honnef.co/go/tools/cmd/unused
-	unused -exported $(SRCS)
+	@unused -exported $(SRCS)
 
 .PHONY: version
 version:

--- a/internal/tunnel/registry.go
+++ b/internal/tunnel/registry.go
@@ -1,0 +1,78 @@
+package tunnel
+
+import (
+	"sync"
+)
+
+// Registry key/tunnel map protected by a RWMutex
+// The registry is a temporary mechanism used to enforce thread-safety.
+// It is likely to replaced/removed with an update to the informers.
+type Registry struct {
+	mu  sync.RWMutex
+	obj map[string]Tunnel
+}
+
+// Load recovers a tunnel by key
+func (r *Registry) Load(key string) (val Tunnel, ok bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	val, ok = r.obj[key]
+	return
+}
+
+// Store registers a tunnel by key
+func (r *Registry) Store(key string, val Tunnel) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.obj == nil {
+		r.obj = make(map[string]Tunnel)
+	}
+	r.obj[key] = val
+}
+
+// Delete removes a tunnel by key
+func (r *Registry) Delete(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.obj, key)
+	return
+}
+
+// LoadAndDelete deletes the tunnel by key and returns the stored value
+func (r *Registry) LoadAndDelete(key string) (val Tunnel, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if val, ok = r.obj[key]; ok {
+		delete(r.obj, key)
+	}
+	return
+}
+
+// Range processes the function on all tunnels (false terminates iteration).
+func (r *Registry) Range(f func(key string, val Tunnel) bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for k, v := range r.obj {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+// Filter processes the function on all tunnels (true deletes the tunnel).
+func (r *Registry) Filter(f func(key string, val Tunnel) bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k, v := range r.obj {
+		if f(k, v) {
+			delete(r.obj, k)
+		}
+	}
+}
+
+// Len returns the number of items in the registry
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.obj)
+}

--- a/internal/tunnel/registry_test.go
+++ b/internal/tunnel/registry_test.go
@@ -1,0 +1,472 @@
+package tunnel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The tunnel interface does not provide a unique identifier for the
+// tunnel.  In the tests below, tunnel is mocked to provide a dummy
+// implemention where config can be used to setup and recover an
+// identifying marker (ServiceName) for testing.
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		obj map[string]Tunnel
+		key string
+		tag string
+		ok  bool
+	}{
+		"nil-map": {
+			obj: nil,
+			key: "test",
+			tag: "",
+			ok:  false,
+		},
+		"not-found": {
+			obj: map[string]Tunnel{
+				"unit": nil,
+			},
+			key: "test",
+			tag: "",
+			ok:  false,
+		},
+		"load": {
+			obj: map[string]Tunnel{
+				"test": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test",
+					})
+					return t
+				}(),
+			},
+			key: "test",
+			tag: "test",
+			ok:  true,
+		},
+	} {
+		r := Registry{
+			obj: test.obj,
+		}
+
+		_, ok := r.Load(test.key)
+		tag := func() (tag string) {
+			if r.obj != nil {
+				if t, ok := r.obj[test.key]; ok {
+					tag = t.Config().ServiceName
+				}
+			}
+			return
+		}()
+		assert.Equalf(t, test.ok, ok, "test '%s' ok mismatch", name)
+		assert.Equalf(t, test.tag, tag, "test '%s' tag mismatch", name)
+	}
+}
+
+func TestStore(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		obj map[string]Tunnel
+		key string
+		val Tunnel
+		len int
+	}{
+		"nil-map": {
+			obj: nil,
+			key: "test",
+			val: func() Tunnel {
+				t := &mockTunnel{}
+				t.On("Config").Return(Config{
+					ServiceName: "test",
+				})
+				return t
+			}(),
+			len: 1,
+		},
+		"append": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+			},
+			key: "test-b",
+			val: func() Tunnel {
+				t := &mockTunnel{}
+				t.On("Config").Return(Config{
+					ServiceName: "test-b",
+				})
+				return t
+			}(),
+			len: 2,
+		},
+		"overwrite": {
+			obj: map[string]Tunnel{
+				"test": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+			},
+			key: "test",
+			val: func() Tunnel {
+				t := &mockTunnel{}
+				t.On("Config").Return(Config{
+					ServiceName: "test-b",
+				})
+				return t
+			}(),
+			len: 1,
+		},
+	} {
+		r := Registry{
+			obj: test.obj,
+		}
+
+		r.Store(test.key, test.val)
+		val := func() (t Tunnel) {
+			if r.obj != nil {
+				t, _ = r.obj[test.key]
+			}
+			return
+		}()
+		assert.Equalf(t, test.val, val, "test '%s' store mismatch", name)
+		assert.Equalf(t, test.len, len(r.obj), "test '%s' length mismatch", name)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		obj map[string]Tunnel
+		key string
+		len int
+	}{
+		"nil-map": {
+			obj: nil,
+			key: "test",
+			len: 0,
+		},
+		"not-found": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+			},
+			key: "test",
+			len: 1,
+		},
+		"remove": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+				"test-b": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-b",
+					})
+					return t
+				}(),
+			},
+			key: "test-a",
+			len: 1,
+		},
+	} {
+		r := Registry{
+			obj: test.obj,
+		}
+
+		r.Delete(test.key)
+		out := func() (t Tunnel) {
+			if r.obj != nil {
+				t, _ = r.obj[test.key]
+			}
+			return
+		}()
+		assert.Emptyf(t, out, "test '%s' delete found non-nil tunnel", name)
+		assert.Equalf(t, test.len, len(r.obj), "test '%s' length mismatch", name)
+	}
+}
+
+func TestLoadAndDelete(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		obj map[string]Tunnel
+		key string
+		tag string
+		ok  bool
+		len int
+	}{
+		"nil-map": {
+			obj: nil,
+			key: "test",
+			ok:  false,
+			tag: "",
+			len: 0,
+		},
+		"not-found": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+			},
+			key: "test",
+			ok:  false,
+			tag: "",
+			len: 1,
+		},
+		"load-and-remove": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+				"test-b": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-b",
+					})
+					return t
+				}(),
+			},
+			key: "test-b",
+			ok:  true,
+			tag: "test-b",
+			len: 1,
+		},
+	} {
+		r := Registry{
+			obj: test.obj,
+		}
+
+		val, ok := r.LoadAndDelete(test.key)
+		tag := func() (tag string) {
+			if val != nil {
+				tag = val.Config().ServiceName
+			}
+			return
+		}()
+		out := func() (t Tunnel) {
+			if r.obj != nil {
+				t, _ = r.obj[test.key]
+			}
+			return
+		}()
+		assert.Emptyf(t, out, "test '%s' delete found non-nil tunnel", name)
+		assert.Equalf(t, test.len, len(r.obj), "test '%s' length mismatch", name)
+		assert.Equalf(t, test.ok, ok, "test '%s' ok mismatch", name)
+		assert.Equalf(t, test.tag, tag, "test '%s' tag mismatch", name)
+	}
+}
+
+func TestRange(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		obj map[string]Tunnel
+		key string
+		len int
+	}{
+		"nil-map": {
+			obj: nil,
+			key: "test-a",
+			len: 0,
+		},
+		"visit-none": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+				"test-b": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-b",
+					})
+					return t
+				}(),
+				"test-c": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-c",
+					})
+					return t
+				}(),
+			},
+			key: "test-",
+			len: 1,
+		},
+		"visit-all": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+				"test-b": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-b",
+					})
+					return t
+				}(),
+				"test-c": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-c",
+					})
+					return t
+				}(),
+			},
+			key: "test-z",
+			len: 3,
+		},
+	} {
+		r := Registry{
+			obj: test.obj,
+		}
+
+		len := 0
+		r.Range(func(k string, t Tunnel) bool {
+			len++
+			return !strings.Contains(k, test.key)
+		})
+
+		assert.Equalf(t, test.len, len, "test '%s' length mismatch", name)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		obj map[string]Tunnel
+		key string
+		len int
+	}{
+		"nil-map": {
+			obj: nil,
+			key: "test-a",
+			len: 0,
+		},
+		"filter-none": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+				"test-b": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-b",
+					})
+					return t
+				}(),
+				"test-c": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-c",
+					})
+					return t
+				}(),
+			},
+			key: "test-z",
+			len: 3,
+		},
+		"filter-one": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+				"test-b": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-b",
+					})
+					return t
+				}(),
+				"test-c": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-c",
+					})
+					return t
+				}(),
+			},
+			key: "test-b",
+			len: 2,
+		},
+		"filter-all": {
+			obj: map[string]Tunnel{
+				"test-a": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-a",
+					})
+					return t
+				}(),
+				"test-b": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-b",
+					})
+					return t
+				}(),
+				"test-c": func() Tunnel {
+					t := &mockTunnel{}
+					t.On("Config").Return(Config{
+						ServiceName: "test-c",
+					})
+					return t
+				}(),
+			},
+			key: "test-",
+			len: 0,
+		},
+	} {
+		r := Registry{
+			obj: test.obj,
+		}
+
+		r.Filter(func(k string, t Tunnel) bool {
+			return strings.Contains(k, test.key)
+		})
+
+		assert.Equalf(t, test.len, len(r.obj), "test '%s' length mismatch", name)
+	}
+}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -1,0 +1,39 @@
+package tunnel
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type mockTunnel struct {
+	mock.Mock
+}
+
+func (t *mockTunnel) Config() Config {
+	args := t.Called()
+	return args.Get(0).(Config)
+}
+
+func (t *mockTunnel) Start(serviceURL string) error {
+	args := t.Called(serviceURL)
+	return args.Error(0)
+}
+
+func (t *mockTunnel) Stop() error {
+	args := t.Called()
+	return args.Error(0)
+}
+
+func (t *mockTunnel) Active() bool {
+	args := t.Called()
+	return args.Get(0).(bool)
+}
+
+func (t *mockTunnel) TearDown() error {
+	args := t.Called()
+	return args.Error(0)
+}
+
+func (t *mockTunnel) CheckStatus() error {
+	args := t.Called()
+	return args.Error(0)
+}


### PR DESCRIPTION
The change targets resolving thread-safety issues in source.  It does
not resolve thread-safety issues detected in the test code, though the
explicit sleeps have been replaced with more resilient mechanisms
 - tests will wait for caches to sync after running the controller
 - tests will poll for changes at 100ms intervals, timing out at 10s

Enabling race dection as part of the PR checks is not ready. The test
code with race issues will be resolved with the reformer refactor.
Any other error/issues discovered in shared code paths have been
preserved and marked for future fix.

fixes #68