### PR TITLE
re-add resource controls for helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.controller.resources }}
+        resources:
+{{ toYaml .Values.controller.resources | trim | indent 10 }}
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,10 @@ controller:
   ingressClass: argo-tunnel
   logLevel: 2
   replicaCount: 1
-
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
 # Enable load balancing
 # requires load balancing enabled on the cloudflare account.
 loadBalancing:


### PR DESCRIPTION
The original helm chart did offer resource controlls, this adds those
controls back to the helm chart.  Be advised, the cpu and memory limits
have not been vetted and should not be assumed to be suggested values.