### PR TITLE
expand annotations to allow tunnel configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PLATFORMS := \
 	# arm32v6-linux-arm-6
 	# arm32v6-linux-arm-7
 	# x86, consider supporting 32bit
-	# i386-lunix-386
+	# i386-linux-386
 	# QEMU issue, exec failure on apk add
 	# s390x-linux-s390x
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -1,12 +1,29 @@
 # Argo Tunnel Ingress Controls
 
 ### Ingress Annotations
-- `kubernetes.io/ingress.class`: the Ingress class that should interpret and serve the Ingress.
+- `kubernetes.io/ingress.class`: the Ingress class that should interpret and serve the Ingress
   - defaults to `argo-tunnel`
   - override with the command-line option `--ingressClass=`
+- `argo.cloudflare.com/compression-quality`: Use cross-stream compression instead HTTP compression.
+  - defaults to `"0"`
+  - quality:
+    - 0 - off
+    - 1 - low
+    - 2 - medium
+    - >=3 - high
+- `argo.cloudflare.com/ha-connections`: the number of high-availability connections to establish
+  - defaults to `"4"`
+- `argo.cloudflare.com/heartbeat-count`: minimum number of unacknowledged heartbeats to send before closing the connection
+  - defaults to `"5"`
+- `argo.cloudflare.com/heartbeat-interval`: minimum idle time before sending a heartbeat
+  - defaults to `"5s"`
 - `argo.cloudflare.com/lb-pool`: attach a Cloudflare loadbalancer for high-availability
   - load-balancing must be enabled for the Cloudflare account
   - allows balancing traffic across clusters
+- `argo.cloudflare.com/no-chunked-encoding`: disables chunked transfer encoding; useful if you are running a WSGI server
+  - defaults to `"false"`
+- `argo.cloudflare.com/retries`: maximum number of retries for connection/protocol errors.
+  - defaults to `"5"`
 
 ### Secret Labels
 - `cloudflare-argo/domain`: the label is required to pair a secret with a domain

--- a/internal/controller/annotations_test.go
+++ b/internal/controller/annotations_test.go
@@ -2,22 +2,28 @@ package controller
 
 import (
 	"testing"
+	"time"
+
+	"github.com/cloudflare/cloudflare-ingress-controller/internal/tunnel"
 
 	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIngressClassAnnotation(t *testing.T) {
+func TestParseIngressClassAnnotation(t *testing.T) {
 	t.Parallel()
 	for name, test := range map[string]struct {
 		in  *v1beta1.Ingress
 		out string
+		ok  bool
 	}{
 		"empty-ingress": {
 			in:  &v1beta1.Ingress{},
 			out: "",
+			ok:  false,
 		},
 		"without-ingress-class": {
 			in: &v1beta1.Ingress{
@@ -34,6 +40,7 @@ func TestIngressClassAnnotation(t *testing.T) {
 				},
 			},
 			out: "",
+			ok:  false,
 		},
 		"with-ingress-class": {
 			in: &v1beta1.Ingress{
@@ -50,24 +57,187 @@ func TestIngressClassAnnotation(t *testing.T) {
 				},
 			},
 			out: "test",
+			ok:  true,
 		},
 	} {
-		out, _ := parseIngressClass(test.in)
+		out, ok := parseIngressClass(test.in)
+		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+		assert.Equalf(t, test.ok, ok, "test '%s' found mismatch", name)
+	}
+}
+
+func TestParseIngressTunnelOptions(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *v1beta1.Ingress
+		out tunnel.Options
+	}{
+		"empty-ingress": {
+			in:  &v1beta1.Ingress{},
+			out: tunnel.CollectOptions(nil),
+		},
+		"without-options": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						annotationIngressClass: "test",
+					},
+				},
+			},
+			out: tunnel.CollectOptions(nil),
+		},
+		"without-some-options": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						annotationIngressClass:         "test",
+						annotationIngressHAConnections: "2",
+						annotationIngressLoadBalancer:  "test-lb-pool",
+						annotationIngressRetries:       "8",
+					},
+				},
+			},
+			out: tunnel.Options{
+				HaConnections:     2,
+				HeartbeatCount:    5,
+				HeartbeatInterval: 5 * time.Second,
+				LbPool:            "test-lb-pool",
+				Retries:           8,
+			},
+		},
+		"with-all-options": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						annotationIngressClass:              "test",
+						annotationIngressCompressionQuality: "1",
+						annotationIngressHAConnections:      "2",
+						annotationIngressHeartbeatCount:     "4",
+						annotationIngressHeartbeatInterval:  "4ms",
+						annotationIngressLoadBalancer:       "test-lb-pool",
+						annotationIngressNoChunkedEncoding:  "true",
+						annotationIngressRetries:            "8",
+					},
+				},
+			},
+			out: tunnel.Options{
+				CompressionQuality: 1,
+				HaConnections:      2,
+				HeartbeatCount:     4,
+				HeartbeatInterval:  4 * time.Millisecond,
+				LbPool:             "test-lb-pool",
+				NoChunkedEncoding:  true,
+				Retries:            8,
+			},
+		},
+	} {
+		out := tunnel.CollectOptions(parseIngressTunnelOptions(test.in))
 		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
 	}
 }
 
-func TestIngressLoadBalancerAnnotation(t *testing.T) {
+func TestParseMetaBool(t *testing.T) {
 	t.Parallel()
 	for name, test := range map[string]struct {
 		in  *v1beta1.Ingress
-		out string
+		out bool
+		ok  bool
+	}{
+		"empty-meta": {
+			in:  &v1beta1.Ingress{},
+			out: false,
+			ok:  false,
+		},
+		"with-any-other-value": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "any-other-value",
+					},
+				},
+			},
+			out: false,
+			ok:  false,
+		},
+		"with-false": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "false",
+					},
+				},
+			},
+			out: false,
+			ok:  true,
+		},
+		"with-true": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "true",
+					},
+				},
+			},
+			out: true,
+			ok:  true,
+		},
+	} {
+		obj, _ := meta.Accessor(test.in)
+		out, ok := parseMetaBool(obj, "test")
+		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+		assert.Equalf(t, test.ok, ok, "test '%s' found mismatch", name)
+	}
+}
+
+func TestParseMetaDuration(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *v1beta1.Ingress
+		out time.Duration
+		ok  bool
 	}{
 		"empty-ingress": {
 			in:  &v1beta1.Ingress{},
-			out: "",
+			out: 0,
+			ok:  false,
 		},
-		"without-ingress-lb-pool": {
+		"with-non-duration": {
 			in: &v1beta1.Ingress{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Ingress",
@@ -77,13 +247,14 @@ func TestIngressLoadBalancerAnnotation(t *testing.T) {
 					Name:      "test",
 					Namespace: "test",
 					Annotations: map[string]string{
-						annotationIngressLoadBalancer + "-without": "test",
+						"test": "not-a-duration",
 					},
 				},
 			},
-			out: "",
+			out: 0,
+			ok:  false,
 		},
-		"with-ingress-lb-pool": {
+		"with-duration": {
 			in: &v1beta1.Ingress{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Ingress",
@@ -93,14 +264,179 @@ func TestIngressLoadBalancerAnnotation(t *testing.T) {
 					Name:      "test",
 					Namespace: "test",
 					Annotations: map[string]string{
-						annotationIngressLoadBalancer: "test",
+						"test": "100ms",
 					},
 				},
 			},
-			out: "test",
+			out: 100 * time.Millisecond,
+			ok:  true,
 		},
 	} {
-		out, _ := parseIngressLoadBalancer(test.in)
+		obj, _ := meta.Accessor(test.in)
+		out, ok := parseMetaDuration(obj, "test")
 		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+		assert.Equalf(t, test.ok, ok, "test '%s' found mismatch", name)
+	}
+}
+
+func TestParseMetaInt(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *v1beta1.Ingress
+		out uint
+		ok  bool
+	}{
+		"empty-ingress": {
+			in:  &v1beta1.Ingress{},
+			out: 0,
+			ok:  false,
+		},
+		"with-non-int": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "non-numeric",
+					},
+				},
+			},
+			out: 0,
+			ok:  false,
+		},
+		"with-int": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "9",
+					},
+				},
+			},
+			out: 9,
+			ok:  true,
+		},
+	} {
+		obj, _ := meta.Accessor(test.in)
+		out, ok := parseMetaUint(obj, "test")
+		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+		assert.Equalf(t, test.ok, ok, "test '%s' found mismatch", name)
+	}
+}
+
+func TestParseMetaUint(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *v1beta1.Ingress
+		out uint
+		ok  bool
+	}{
+		"empty-ingress": {
+			in:  &v1beta1.Ingress{},
+			out: 0,
+			ok:  false,
+		},
+		"with-non-uint": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "-9",
+					},
+				},
+			},
+			out: 0,
+			ok:  false,
+		},
+		"with-uint": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "9",
+					},
+				},
+			},
+			out: 9,
+			ok:  true,
+		},
+	} {
+		obj, _ := meta.Accessor(test.in)
+		out, ok := parseMetaUint(obj, "test")
+		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+		assert.Equalf(t, test.ok, ok, "test '%s' found mismatch", name)
+	}
+}
+
+func TestParseMetaUint64(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *v1beta1.Ingress
+		out uint
+		ok  bool
+	}{
+		"empty-ingress": {
+			in:  &v1beta1.Ingress{},
+			out: 0,
+			ok:  false,
+		},
+		"with-non-uint64": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "-8",
+					},
+				},
+			},
+			out: 0,
+			ok:  false,
+		},
+		"with-uint64": {
+			in: &v1beta1.Ingress{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Ingress",
+					APIVersion: "extensions/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"test": "8",
+					},
+				},
+			},
+			out: 8,
+			ok:  true,
+		},
+	} {
+		obj, _ := meta.Accessor(test.in)
+		out, ok := parseMetaUint(obj, "test")
+		assert.Equalf(t, test.out, out, "test '%s' value mismatch", name)
+		assert.Equalf(t, test.ok, ok, "test '%s' found mismatch", name)
 	}
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudflare/cloudflare-ingress-controller/internal/tunnel"
+
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
@@ -327,10 +329,10 @@ func TestControllerLookups(t *testing.T) {
 
 	// broken for now
 	// assert.Equal(t, "fooservice", wc.getServiceNameForIngress(&items.Ingress))
-	lbpool, _ := parseIngressLoadBalancer(&items.Ingress)
+	opts := tunnel.CollectOptions(parseIngressTunnelOptions(&items.Ingress))
 	assert.Equal(t, "test.example.com", wc.getHostNameForIngress(&items.Ingress))
 	assert.Equal(t, int32(80), wc.getServicePortForIngress(&items.Ingress).IntVal)
-	assert.Equal(t, "testpool", lbpool)
+	assert.Equal(t, "testpool", opts.LbPool)
 	// assert.Equal(t, "test.example.com", wc.getLBPoolForIngress(&items.Ingress))
 }
 
@@ -391,9 +393,9 @@ func TestTunnelInitialization(t *testing.T) {
 		t.Fatalf("failing, tunnel is nil for %s", key)
 	}
 	assert.False(t, fooTunnel.Active())
-	assert.Equal(t, "test.example.com", fooTunnel.Config().ExternalHostname)
-	assert.Equal(t, "fooservice", fooTunnel.Config().ServiceName)
-	assert.Equal(t, int32(80), fooTunnel.Config().ServicePort.IntVal)
+	assert.Equal(t, "test.example.com", fooTunnel.Route().ExternalHostname)
+	assert.Equal(t, "fooservice", fooTunnel.Route().ServiceName)
+	assert.Equal(t, int32(80), fooTunnel.Route().ServicePort.IntVal)
 
 }
 
@@ -462,9 +464,9 @@ func TestTunnelServiceInitialization(t *testing.T) {
 		t.Fatalf("failing, tunnel is nil for %s", key)
 	}
 	assert.False(t, fooTunnel.Active())
-	assert.Equal(t, "test.example.com", fooTunnel.Config().ExternalHostname)
-	assert.Equal(t, "fooservice", fooTunnel.Config().ServiceName)
-	assert.Equal(t, int32(80), fooTunnel.Config().ServicePort.IntVal)
+	assert.Equal(t, "test.example.com", fooTunnel.Route().ExternalHostname)
+	assert.Equal(t, "fooservice", fooTunnel.Route().ServiceName)
+	assert.Equal(t, int32(80), fooTunnel.Route().ServicePort.IntVal)
 
 }
 
@@ -552,8 +554,8 @@ func TestTunnelServicesTwoNS(t *testing.T) {
 			t.Fatalf("failing, tunnel is nil for %s", key)
 		}
 		assert.False(t, tunnel.Active())
-		assert.Equal(t, "test.example.com", tunnel.Config().ExternalHostname)
-		assert.Equal(t, "fooservice", tunnel.Config().ServiceName)
-		assert.Equal(t, int32(80), tunnel.Config().ServicePort.IntVal)
+		assert.Equal(t, "test.example.com", tunnel.Route().ExternalHostname)
+		assert.Equal(t, "fooservice", tunnel.Route().ServiceName)
+		assert.Equal(t, int32(80), tunnel.Route().ServicePort.IntVal)
 	}
 }

--- a/internal/tunnel/argo_test.go
+++ b/internal/tunnel/argo_test.go
@@ -8,35 +8,34 @@ import (
 )
 
 func TestArgoTunnelConfig(t *testing.T) {
-
-	config := &Config{
-		ServiceName:      "service",
-		ServiceNamespace: "default",
+	route := Route{
+		ServiceName:      "acme",
 		ServicePort:      intstr.FromInt(6000),
+		IngressName:      "acme",
+		Namespace:        "default",
 		ExternalHostname: "acme.example.com",
-		LBPool:           "abc123",
 		OriginCert:       []byte("this is not a cert"),
 		Version:          "test",
 	}
 
-	tunnel, err := NewArgoTunnel(config)
+	tunnel, err := NewArgoTunnel(route)
 	assert.Nil(t, err)
 
 	argot := tunnel.(*ArgoTunnel)
 	assert.NotNil(t, argot)
 
-	assert.Equal(t, argot.tunnelConfig.Hostname, config.ExternalHostname)
-	assert.Equal(t, argot.tunnelConfig.LBPool, config.LBPool)
-	assert.Equal(t, argot.tunnelConfig.OriginCert, config.OriginCert)
+	assert.Equal(t, argot.tunnelConfig.Hostname, route.ExternalHostname)
+	assert.Equal(t, argot.tunnelConfig.OriginCert, route.OriginCert)
 
-	assert.Equal(t, argot.tunnelConfig.HAConnections, haConnectionsDefault)
+	assert.Equal(t, argot.tunnelConfig.HAConnections, HaConnectionsDefault)
+	assert.Equal(t, argot.tunnelConfig.Retries, RetriesDefault)
 	assert.NotNil(t, argot.tunnelConfig.ProtocolLogger)
 
-	assert.Equal(t, argot.config.ServiceName, config.ServiceName)
-	assert.Equal(t, argot.config.ServicePort, config.ServicePort)
+	assert.Equal(t, argot.route.ServiceName, route.ServiceName)
+	assert.Equal(t, argot.route.ServicePort, route.ServicePort)
 
 	// TODO write a test for the post-start condition where the origin url and port have been determined
-	//assert.Equal(t, fmt.Sprintf("%s.%s:%d", config.ServiceName, config.ServiceNamespace, config.ServicePort.IntValue()), argot.tunnelConfig.OriginUrl)
+	//assert.Equal(t, fmt.Sprintf("%s.%s:%d", config.ServiceName, config.Namespace, config.ServicePort.IntValue()), argot.tunnelConfig.OriginUrl)
 	assert.Equal(t, "", argot.tunnelConfig.OriginUrl)
 
 	assert.False(t, argot.Active())

--- a/internal/tunnel/options.go
+++ b/internal/tunnel/options.go
@@ -1,0 +1,107 @@
+package tunnel
+
+import (
+	"time"
+)
+
+const (
+	// HaConnectionsDefault defines the default high-availability connections
+	HaConnectionsDefault = 4
+	// HeartbeatCountDefault defines the default heartbeat count
+	// Minimum number of unacknowledged heartbeats to send before closing the connection.
+	HeartbeatCountDefault = uint64(5)
+	// HeartbeatIntervalDefault defines the default interval between heartbeats
+	// Minimum number of unacked heartbeats to send before closing the connection.
+	HeartbeatIntervalDefault = time.Second * 5
+	// RetriesDefault defines the default number of attempts to repair on failure
+	// Maximum number of retries for connection/protocol errors.
+	RetriesDefault = uint(5)
+)
+
+// Options optional tunnel behavior configurations
+// todo: change to not-exported with resource handling refactor
+type Options struct {
+	CompressionQuality uint64
+	GracePeriod        time.Duration
+	HaConnections      int
+	HeartbeatCount     uint64
+	HeartbeatInterval  time.Duration
+	LbPool             string
+	NoChunkedEncoding  bool
+	Retries            uint
+}
+
+// Option provides behavior overrides
+type Option func(*Options)
+
+// CompressionQuality sets tunnel compressions quality
+func CompressionQuality(i uint64) Option {
+	return func(o *Options) {
+		o.CompressionQuality = i
+	}
+}
+
+// DisableChunkedEncoding disable chunked encoding
+func DisableChunkedEncoding(b bool) Option {
+	return func(o *Options) {
+		o.NoChunkedEncoding = b
+	}
+}
+
+// GracePeriod sets tunnel grace period
+func GracePeriod(d time.Duration) Option {
+	return func(o *Options) {
+		o.GracePeriod = d
+	}
+}
+
+// HaConnections sets tunnel ha connections
+func HaConnections(i int) Option {
+	return func(o *Options) {
+		o.HaConnections = i
+	}
+}
+
+// HeartbeatCount sets tunnel heartbeat count
+func HeartbeatCount(i uint64) Option {
+	return func(o *Options) {
+		o.HeartbeatCount = i
+	}
+}
+
+// HeartbeatInterval sets tunnel heartbeat interval
+func HeartbeatInterval(d time.Duration) Option {
+	return func(o *Options) {
+		o.HeartbeatInterval = d
+	}
+}
+
+// LbPool sets tunnel load balancer pool
+func LbPool(s string) Option {
+	return func(o *Options) {
+		o.LbPool = s
+	}
+}
+
+// Retries sets tunnel retries
+func Retries(i uint) Option {
+	return func(o *Options) {
+		o.Retries = i
+	}
+}
+
+// CollectOptions flattens an array of Option into an Options struct
+func CollectOptions(opts []Option) Options {
+	// set option defaults
+	o := Options{
+		HaConnections:     HaConnectionsDefault,
+		HeartbeatCount:    HeartbeatCountDefault,
+		HeartbeatInterval: HeartbeatIntervalDefault,
+		Retries:           RetriesDefault,
+	}
+	// overlay option values
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}

--- a/internal/tunnel/options_test.go
+++ b/internal/tunnel/options_test.go
@@ -1,0 +1,61 @@
+package tunnel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptions(t *testing.T) {
+	for name, test := range map[string]struct {
+		in  []Option
+		out Options
+	}{
+		"default-options": {
+			in: []Option{},
+			out: Options{
+				HaConnections:     HaConnectionsDefault,
+				HeartbeatCount:    HeartbeatCountDefault,
+				HeartbeatInterval: HeartbeatIntervalDefault,
+				Retries:           RetriesDefault,
+			},
+		},
+		"set-one-option": {
+			in: []Option{
+				Retries(100),
+			},
+			out: Options{
+				HaConnections:     HaConnectionsDefault,
+				HeartbeatCount:    HeartbeatCountDefault,
+				HeartbeatInterval: HeartbeatIntervalDefault,
+				Retries:           100,
+			},
+		},
+		"set-all-options": {
+			in: []Option{
+				CompressionQuality(8),
+				DisableChunkedEncoding(true),
+				GracePeriod(100 * time.Millisecond),
+				HaConnections(8),
+				HeartbeatCount(100),
+				HeartbeatInterval(100 * time.Millisecond),
+				LbPool("test-lb"),
+				Retries(100),
+			},
+			out: Options{
+				CompressionQuality: 8,
+				NoChunkedEncoding:  true,
+				GracePeriod:        100 * time.Millisecond,
+				HaConnections:      8,
+				HeartbeatCount:     100,
+				HeartbeatInterval:  100 * time.Millisecond,
+				LbPool:             "test-lb",
+				Retries:            100,
+			},
+		},
+	} {
+		out := CollectOptions(test.in)
+		assert.Equalf(t, test.out, out, "test '%s' options mismatch", name)
+	}
+}

--- a/internal/tunnel/registry_test.go
+++ b/internal/tunnel/registry_test.go
@@ -38,7 +38,7 @@ func TestLoad(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test",
 					})
 					return t
@@ -57,7 +57,7 @@ func TestLoad(t *testing.T) {
 		tag := func() (tag string) {
 			if r.obj != nil {
 				if t, ok := r.obj[test.key]; ok {
-					tag = t.Config().ServiceName
+					tag = t.Route().ServiceName
 				}
 			}
 			return
@@ -80,7 +80,7 @@ func TestStore(t *testing.T) {
 			key: "test",
 			val: func() Tunnel {
 				t := &mockTunnel{}
-				t.On("Config").Return(Config{
+				t.On("Route").Return(Route{
 					ServiceName: "test",
 				})
 				return t
@@ -91,7 +91,7 @@ func TestStore(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
@@ -100,7 +100,7 @@ func TestStore(t *testing.T) {
 			key: "test-b",
 			val: func() Tunnel {
 				t := &mockTunnel{}
-				t.On("Config").Return(Config{
+				t.On("Route").Return(Route{
 					ServiceName: "test-b",
 				})
 				return t
@@ -111,7 +111,7 @@ func TestStore(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
@@ -120,7 +120,7 @@ func TestStore(t *testing.T) {
 			key: "test",
 			val: func() Tunnel {
 				t := &mockTunnel{}
-				t.On("Config").Return(Config{
+				t.On("Route").Return(Route{
 					ServiceName: "test-b",
 				})
 				return t
@@ -160,7 +160,7 @@ func TestDelete(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
@@ -173,14 +173,14 @@ func TestDelete(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
 				}(),
 				"test-b": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-b",
 					})
 					return t
@@ -226,7 +226,7 @@ func TestLoadAndDelete(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
@@ -241,14 +241,14 @@ func TestLoadAndDelete(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
 				}(),
 				"test-b": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-b",
 					})
 					return t
@@ -267,7 +267,7 @@ func TestLoadAndDelete(t *testing.T) {
 		val, ok := r.LoadAndDelete(test.key)
 		tag := func() (tag string) {
 			if val != nil {
-				tag = val.Config().ServiceName
+				tag = val.Route().ServiceName
 			}
 			return
 		}()
@@ -300,21 +300,21 @@ func TestRange(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
 				}(),
 				"test-b": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-b",
 					})
 					return t
 				}(),
 				"test-c": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-c",
 					})
 					return t
@@ -327,21 +327,21 @@ func TestRange(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
 				}(),
 				"test-b": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-b",
 					})
 					return t
 				}(),
 				"test-c": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-c",
 					})
 					return t
@@ -381,21 +381,21 @@ func TestFilter(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
 				}(),
 				"test-b": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-b",
 					})
 					return t
 				}(),
 				"test-c": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-c",
 					})
 					return t
@@ -408,21 +408,21 @@ func TestFilter(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
 				}(),
 				"test-b": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-b",
 					})
 					return t
 				}(),
 				"test-c": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-c",
 					})
 					return t
@@ -435,21 +435,21 @@ func TestFilter(t *testing.T) {
 			obj: map[string]Tunnel{
 				"test-a": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-a",
 					})
 					return t
 				}(),
 				"test-b": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-b",
 					})
 					return t
 				}(),
 				"test-c": func() Tunnel {
 					t := &mockTunnel{}
-					t.On("Config").Return(Config{
+					t.On("Route").Return(Route{
 						ServiceName: "test-c",
 					})
 					return t

--- a/internal/tunnel/route.go
+++ b/internal/tunnel/route.go
@@ -1,0 +1,16 @@
+package tunnel
+
+import (
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Route describes the path to the origin
+type Route struct {
+	ServiceName      string
+	ServicePort      intstr.IntOrString // maps either to service.Name (string) or service.Port (int32)
+	IngressName      string
+	Namespace        string
+	ExternalHostname string
+	OriginCert       []byte
+	Version          string
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1,18 +1,17 @@
 package tunnel
 
-import (
-	"k8s.io/apimachinery/pkg/util/intstr"
-)
-
 // Tunnel is the interface for different implementation of
 // the argo tunnel, matching an external hostname
 // to a kubernetes service
 type Tunnel interface {
 
-	// Config returns the tunnel configuration
-	Config() Config
+	// Route returns the tunnel configuration
+	Route() Route
 
-	// Start the tunnel to connect ot a particular service url, making it active
+	// Options returns the tunnel options
+	Options() Options
+
+	// Start the tunnel to connect to a particular service url, making it active
 	Start(serviceURL string) error
 
 	// Stop the tunnel, making it inactive
@@ -26,17 +25,4 @@ type Tunnel interface {
 
 	// CheckStatus validates the current state of the tunnel
 	CheckStatus() error
-}
-
-// Config contains the smallest set of elements to define
-// an argo tunnel
-type Config struct {
-	ServiceName      string
-	ServiceNamespace string
-	ServicePort      intstr.IntOrString // maps either to service.Name (string) or service.Port (int32)
-	IngressName      string
-	ExternalHostname string
-	LBPool           string
-	OriginCert       []byte
-	Version          string
 }

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -8,9 +8,14 @@ type mockTunnel struct {
 	mock.Mock
 }
 
-func (t *mockTunnel) Config() Config {
+func (t *mockTunnel) Route() Route {
 	args := t.Called()
-	return args.Get(0).(Config)
+	return args.Get(0).(Route)
+}
+
+func (t *mockTunnel) Options() Options {
+	args := t.Called()
+	return args.Get(0).(Options)
 }
 
 func (t *mockTunnel) Start(serviceURL string) error {


### PR DESCRIPTION
The change expands the set of annotations allow as part of the ingress
definition, allowing control similar to `cloudflared` command-line
flags. This expansion does not offer http transport configuration (e.g.
adjustment to proxy settings).