### PR TITLE
replace glog with logrus

### DIFF
--- a/cmd/argot/main_test.go
+++ b/cmd/argot/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"flag"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type Level int32
+
+// set sets the value of the Level.
+func (l *Level) set(val Level) {
+	atomic.StoreInt32((*int32)(l), int32(val))
+}
+
+// String is part of the flag.Value interface.
+func (l *Level) String() string {
+	return strconv.FormatInt(int64(*l), 10)
+}
+
+// Get is part of the flag.Value interface.
+func (l *Level) Get() interface{} {
+	return *l
+}
+
+// Set is part of the flag.Value interface.
+func (l *Level) Set(value string) error {
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	l.set(Level(v))
+	return nil
+}
+func TestLogLevel(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  []string
+		out logrus.Level
+	}{
+		"verbose-flag-missing": {
+			in:  []string{},
+			out: logrus.PanicLevel,
+		},
+		"verbose-flag-0": {
+			in:  []string{"--v=0"},
+			out: logrus.PanicLevel,
+		},
+		"verbose-flag-1": {
+			in:  []string{"--v=1"},
+			out: logrus.FatalLevel,
+		},
+		"verbose-flag-2": {
+			in:  []string{"--v=2"},
+			out: logrus.ErrorLevel,
+		},
+		"verbose-flag-3": {
+			in:  []string{"--v=3"},
+			out: logrus.WarnLevel,
+		},
+		"verbose-flag-4": {
+			in:  []string{"--v=4"},
+			out: logrus.InfoLevel,
+		},
+		"verbose-flag-5": {
+			in:  []string{"--v=5"},
+			out: logrus.DebugLevel,
+		},
+		"verbose-flag-100": {
+			in:  []string{"--v=100"},
+			out: logrus.DebugLevel,
+		},
+	} {
+		var v Level
+		flags := flag.NewFlagSet(name, flag.ContinueOnError)
+		flags.Var(&v, "v", "log level for V logs")
+		flags.Parse(test.in)
+
+		out := loglevel(flags)
+		assert.Equalf(t, test.out, out, "test '%s' loglevel mismatch", name)
+	}
+}

--- a/internal/tunnel/argo_test.go
+++ b/internal/tunnel/argo_test.go
@@ -3,11 +3,13 @@ package tunnel
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestArgoTunnelConfig(t *testing.T) {
+	logger, hook := test.NewNullLogger()
 	route := Route{
 		ServiceName:      "acme",
 		ServicePort:      intstr.FromInt(6000),
@@ -18,7 +20,7 @@ func TestArgoTunnelConfig(t *testing.T) {
 		Version:          "test",
 	}
 
-	tunnel, err := NewArgoTunnel(route)
+	tunnel, err := NewArgoTunnel(route, logger)
 	assert.Nil(t, err)
 
 	argot := tunnel.(*ArgoTunnel)
@@ -37,6 +39,8 @@ func TestArgoTunnelConfig(t *testing.T) {
 	// TODO write a test for the post-start condition where the origin url and port have been determined
 	//assert.Equal(t, fmt.Sprintf("%s.%s:%d", config.ServiceName, config.Namespace, config.ServicePort.IntValue()), argot.tunnelConfig.OriginUrl)
 	assert.Equal(t, "", argot.tunnelConfig.OriginUrl)
-
 	assert.False(t, argot.Active())
+
+	hook.Reset()
+	assert.Nil(t, hook.LastEntry())
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -4,6 +4,8 @@ package tunnel
 // the argo tunnel, matching an external hostname
 // to a kubernetes service
 type Tunnel interface {
+	// Origin returns the tunnel origin
+	Origin() string
 
 	// Route returns the tunnel configuration
 	Route() Route

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -8,6 +8,11 @@ type mockTunnel struct {
 	mock.Mock
 }
 
+func (t *mockTunnel) Origin() string {
+	args := t.Called()
+	return args.Get(0).(string)
+}
+
 func (t *mockTunnel) Route() Route {
 	args := t.Called()
 	return args.Get(0).(Route)


### PR DESCRIPTION
Previously, the code base leveraged both loggers, glog and logrus, in
different portions of the code.  THis change consolidates loggers to one
variant, logrus.  The kubernentes client internally uses glog, which
defines the --v flag.  To avoid altering the optiosn for 0.5.x, the
mechanism is preserved.  The value for --v is mapped into a logrus level
and set to the shared logger.