### PR TITLE
convert cmd-line flags to cli

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,6 +19,25 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:a74730e052a45a3fab1d310fdef2ec17ae3d6af16228421e238320846f2aaec8"
+  name = "github.com/alecthomas/template"
+  packages = [
+    ".",
+    "parse",
+  ]
+  pruneopts = ""
+  revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8483994d21404c8a1d489f6be756e25bfccd3b45d65821f25695577791a08e68"
+  name = "github.com/alecthomas/units"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
+
+[[projects]]
+  branch = "master"
   digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
@@ -478,6 +497,14 @@
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
+  name = "gopkg.in/alecthomas/kingpin.v2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
+  version = "v2.2.6"
+
+[[projects]]
   digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
   name = "gopkg.in/inf.v0"
   packages = ["."]
@@ -714,6 +741,7 @@
     "github.com/sirupsen/logrus/hooks/test",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
+    "gopkg.in/alecthomas/kingpin.v2",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/meta",

--- a/cmd/argot/main_test.go
+++ b/cmd/argot/main_test.go
@@ -1,86 +1,52 @@
 package main
 
 import (
-	"flag"
-	"strconv"
-	"sync/atomic"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
-type Level int32
-
-// set sets the value of the Level.
-func (l *Level) set(val Level) {
-	atomic.StoreInt32((*int32)(l), int32(val))
-}
-
-// String is part of the flag.Value interface.
-func (l *Level) String() string {
-	return strconv.FormatInt(int64(*l), 10)
-}
-
-// Get is part of the flag.Value interface.
-func (l *Level) Get() interface{} {
-	return *l
-}
-
-// Set is part of the flag.Value interface.
-func (l *Level) Set(value string) error {
-	v, err := strconv.Atoi(value)
-	if err != nil {
-		return err
-	}
-	l.set(Level(v))
-	return nil
-}
-func TestLogLevel(t *testing.T) {
+func TestLogrusLevel(t *testing.T) {
 	t.Parallel()
 	for name, test := range map[string]struct {
-		in  []string
+		in  int
 		out logrus.Level
 	}{
-		"verbose-flag-missing": {
-			in:  []string{},
+		"verbose-flag-lt-0": {
+			in:  -100,
 			out: logrus.PanicLevel,
 		},
 		"verbose-flag-0": {
-			in:  []string{"--v=0"},
+			in:  0,
 			out: logrus.PanicLevel,
 		},
 		"verbose-flag-1": {
-			in:  []string{"--v=1"},
+			in:  1,
 			out: logrus.FatalLevel,
 		},
 		"verbose-flag-2": {
-			in:  []string{"--v=2"},
+			in:  2,
 			out: logrus.ErrorLevel,
 		},
 		"verbose-flag-3": {
-			in:  []string{"--v=3"},
+			in:  3,
 			out: logrus.WarnLevel,
 		},
 		"verbose-flag-4": {
-			in:  []string{"--v=4"},
+			in:  4,
 			out: logrus.InfoLevel,
 		},
 		"verbose-flag-5": {
-			in:  []string{"--v=5"},
+			in:  5,
 			out: logrus.DebugLevel,
 		},
 		"verbose-flag-100": {
-			in:  []string{"--v=100"},
+			in:  100,
 			out: logrus.DebugLevel,
 		},
 	} {
-		var v Level
-		flags := flag.NewFlagSet(name, flag.ContinueOnError)
-		flags.Var(&v, "v", "log level for V logs")
-		flags.Parse(test.in)
-
-		out := loglevel(flags)
-		assert.Equalf(t, test.out, out, "test '%s' loglevel mismatch", name)
+		out := logruslevel(test.in)
+		assert.Equalf(t, test.out, out, "test '%s' logrus level mismatch", name)
 	}
 }

--- a/deploy/argo-tunnel-no-rbac.yaml
+++ b/deploy/argo-tunnel-no-rbac.yaml
@@ -20,14 +20,15 @@ spec:
         app: argo-tunnel
     spec:
       containers:
-      - image: gcr.io/cloudflare-registry/argo-tunnel:0.5.3
+      - image: gcr.io/cloudflare-registry/argo-tunnel:0.6.0
         imagePullPolicy: Always
         name: argo-tunnel
-        command: ["argot"]
+        command: ["argot", "couple"]
         args:
+        - --incluster
+        - --ingress-class=argo-tunnel
+        - --default-origin-secret=$(POD_NAMESPACE)/anydomain
         - --v=2
-        - --ingressClass=argo-tunnel
-        - --namespace=$(POD_NAMESPACE)
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/deploy/argo-tunnel.yaml
+++ b/deploy/argo-tunnel.yaml
@@ -82,14 +82,15 @@ spec:
         app: argo-tunnel
     spec:
       containers:
-      - image: gcr.io/cloudflare-registry/argo-tunnel:0.5.3
+      - image: gcr.io/cloudflare-registry/argo-tunnel:0.6.0
         imagePullPolicy: Always
         name: argo-tunnel
-        command: ["argot"]
+        command: ["argot", "couple"]
         args:
+        - --incluster
+        - --ingress-class=argo-tunnel
+        - --default-origin-secret=$(POD_NAMESPACE)/anydomain
         - --v=2
-        - --ingressClass=argo-tunnel
-        - --namespace=$(POD_NAMESPACE)
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/internal/controller/options.go
+++ b/internal/controller/options.go
@@ -14,7 +14,7 @@ const (
 	// TODO: the concept of a hardcoded default secret name should be deprecated
 	// with the secret namespace, preferring a simple option to define a default
 	// tunnel secret by "namespace/name"
-	SecretNameDefault = "cloudflared-cert"
+	SecretNameDefault = "anydomain"
 )
 
 type options struct {

--- a/internal/k8s/types.go
+++ b/internal/k8s/types.go
@@ -1,0 +1,48 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	objDelim = "/"
+)
+
+// ObjMixin is a kingpin convenience function
+func ObjMixin(s kingpin.Settings) (val *ObjValue) {
+	val = &ObjValue{}
+	s.SetValue(val)
+	return
+}
+
+// Obj is a name namespace tuple
+type Obj struct {
+	Name, Namespace string
+}
+
+// ObjValue is a meta namespace key variant implementing the Value interface
+type ObjValue Obj
+
+// Set values the object from a string or errors.
+func (o *ObjValue) Set(val string) error {
+	parts := strings.SplitN(strings.TrimSpace(val), objDelim, 3)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected '<namespace>/<name>' got '%s'", val)
+	} else if parts[0] == "" {
+		return fmt.Errorf("expected '<namespace>/<name>' got '%s'", val)
+	} else if parts[1] == "" {
+		return fmt.Errorf("expected '<namespace>/<name>' got '%s'", val)
+	}
+	o.Namespace, o.Name = parts[0], parts[1]
+	return nil
+}
+
+func (o *ObjValue) String() (val string) {
+	if o.Namespace != "" && o.Name != "" {
+		val = o.Namespace + objDelim + o.Name
+	}
+	return
+}

--- a/internal/k8s/types_test.go
+++ b/internal/k8s/types_test.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func TestObjMixin(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  string
+		out *ObjValue
+		err error
+	}{
+		"obj-empty": {
+			in:  "",
+			out: &ObjValue{},
+			err: fmt.Errorf("expected '<namespace>/<name>' got '%s'", ""),
+		},
+		"obj-no-name": {
+			in:  "a/",
+			out: &ObjValue{},
+			err: fmt.Errorf("expected '<namespace>/<name>' got '%s'", "a/"),
+		},
+		"obj-no-namespace": {
+			in:  "/b",
+			out: &ObjValue{},
+			err: fmt.Errorf("expected '<namespace>/<name>' got '%s'", "/b"),
+		},
+		"obj-too-many-parts": {
+			in:  "a/b/c",
+			out: &ObjValue{},
+			err: fmt.Errorf("expected '<namespace>/<name>' got '%s'", "a/b/c"),
+		},
+		"obj-okay": {
+			in: "a/b",
+			out: &ObjValue{
+				Namespace: "a",
+				Name:      "b",
+			},
+			err: nil,
+		},
+	} {
+		app := kingpin.New(name, name)
+		out := ObjMixin(app.Flag("o", "test"))
+		_, err := app.Parse([]string{"--o=" + test.in})
+		assert.Equalf(t, test.out, out, "test '%s' obj mismatch", name)
+		assert.Equalf(t, test.err, err, "test '%s' err mismatch", name)
+	}
+}


### PR DESCRIPTION
BREAKING CHANGE from 0.5.x. Migrates flags to command-style cli with 2
commands, version and couple. The change includes removal of the flag
`-namespace`, preferring an alternate to secret location/control.