### PR TITLE
verify certificate for host prior to starting tunnel

### DIFF
--- a/internal/argotunnel/tunnel_test.go
+++ b/internal/argotunnel/tunnel_test.go
@@ -1,7 +1,16 @@
 package argotunnel
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/cloudflare/cloudflared/origin"
 	"github.com/stretchr/testify/assert"
@@ -197,4 +206,76 @@ func TestGetOriginUrl(t *testing.T) {
 		url := getOriginURL(test.rule)
 		assert.Equalf(t, test.url, url, "test '%s' url mismatch", name)
 	}
+}
+
+func TestVerifyCertForHost(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		cert []byte
+		host string
+		err  error
+	}{
+		"cert-empty": {
+			cert: []byte{},
+			host: "",
+			err:  fmt.Errorf("pem contains no certificate"),
+		},
+		"cert-host-mismatch": {
+			cert: genCertforHost("host.unit.com"),
+			host: "host.notforcert.com",
+			err:  fmt.Errorf("x509: certificate is valid for host.unit.com, not host.notforcert.com"),
+		},
+		"cert-host-match": {
+			cert: genCertforHost("host.unit.com"),
+			host: "host.unit.com",
+			err:  nil,
+		},
+	} {
+		err := func() error {
+			e := verifyCertForHost(test.cert, test.host)
+			switch e.(type) {
+			case x509.HostnameError:
+				return fmt.Errorf(e.Error())
+			default:
+				return e
+			}
+		}()
+		assert.Equalf(t, test.err, err, "test '%s' error mismatch", name)
+	}
+}
+
+func genCertforHost(host string) (cert []byte) {
+	template := x509.Certificate{
+		SerialNumber: func() (n *big.Int) {
+			list := new(big.Int).Lsh(big.NewInt(1), 128)
+			n, err := rand.Int(rand.Reader, list)
+			if err != nil {
+				n = big.NewInt(0)
+			}
+			return
+		}(),
+		Subject: pkix.Name{
+			Organization: []string{"Unit Co"},
+		},
+		DNSNames: []string{
+			host,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(12 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	var pub interface{}
+	var priv interface{}
+	priv, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	pub = &priv.(*ecdsa.PrivateKey).PublicKey
+
+	rawBytes, _ := x509.CreateCertificate(rand.Reader, &template, &template, pub, priv)
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: rawBytes,
+	})
+	return pemBytes
 }


### PR DESCRIPTION
The certificate should be checked for the host prior to launching a
tunnel; otherwise, starting the tunnel will trigger the repair loop.