### PR TITLE
verify service target port matches an endpoint port

### DIFF
--- a/internal/argotunnel/translator.go
+++ b/internal/argotunnel/translator.go
@@ -280,7 +280,7 @@ func (t *syncTranslator) getVerifiedPort(namespace, name string, port intstr.Int
 		return
 	}
 
-	v, exists := k8s.GetServicePort(obj.(*v1.Service), port)
+	svcport, exists := k8s.GetServicePort(obj.(*v1.Service), port)
 	if !exists {
 		err = fmt.Errorf("service '%s' missing port '%s'", key, port.String())
 		return
@@ -294,13 +294,12 @@ func (t *syncTranslator) getVerifiedPort(namespace, name string, port intstr.Int
 		return
 	}
 
-	exists = k8s.EndpointsHaveSubsets(obj.(*v1.Endpoints))
+	_, exists = k8s.GetEndpointsPort(obj.(*v1.Endpoints), svcport.TargetPort)
 	if !exists {
 		err = fmt.Errorf("endpoints '%s' missing subsets", key)
 		return
 	}
 
-	// TODO: verify that the service port matches subset ports
-	val = v
+	val = svcport.Port
 	return
 }

--- a/internal/argotunnel/translator_test.go
+++ b/internal/argotunnel/translator_test.go
@@ -166,10 +166,10 @@ func TestGetRouteFromIngress(t *testing.T) {
 							idx.On("GetByKey", "unit/svc-a").Return(&v1.Endpoints{
 								Subsets: []v1.EndpointSubset{
 									{
-										Addresses: []v1.EndpointAddress{
+										Ports: []v1.EndpointPort{
 											{
-												IP:       "x.x.x.x",
-												Hostname: "a.unit.com",
+												Name: "http",
+												Port: 9090,
 											},
 										},
 									},
@@ -201,8 +201,9 @@ func TestGetRouteFromIngress(t *testing.T) {
 								Spec: v1.ServiceSpec{
 									Ports: []v1.ServicePort{
 										{
-											Name: "http",
-											Port: 8080,
+											Name:       "http",
+											Port:       8080,
+											TargetPort: intstr.FromInt(9090),
 										},
 									},
 								},
@@ -646,15 +647,10 @@ func TestGetVerifiedPort(t *testing.T) {
 							idx.On("GetByKey", "unit/svc-a").Return(&v1.Endpoints{
 								Subsets: []v1.EndpointSubset{
 									{
-										Addresses: []v1.EndpointAddress{
-											{
-												IP: "x.x.x.x",
-											},
-										},
 										Ports: []v1.EndpointPort{
 											{
 												Name: "port-a",
-												Port: 8080,
+												Port: 9090,
 											},
 										},
 									},
@@ -672,8 +668,9 @@ func TestGetVerifiedPort(t *testing.T) {
 								Spec: v1.ServiceSpec{
 									Ports: []v1.ServicePort{
 										{
-											Name: "port-a",
-											Port: 8080,
+											Name:       "port-a",
+											Port:       8080,
+											TargetPort: intstr.FromInt(9090),
 										},
 									},
 								},

--- a/internal/k8s/audit.go
+++ b/internal/k8s/audit.go
@@ -10,16 +10,26 @@ const (
 	CertPem = "cert.pem"
 )
 
-// EndpointsHaveSubsets verify that subsets exist
-func EndpointsHaveSubsets(ep *v1.Endpoints) bool {
+// GetEndpointsPort extracts the matching endpoints port
+func GetEndpointsPort(ep *v1.Endpoints, port intstr.IntOrString) (val v1.EndpointPort, exists bool) {
 	if ep != nil {
 		for _, subset := range ep.Subsets {
-			if len(subset.Addresses) > 0 {
-				return true
+			for _, subsetPort := range subset.Ports {
+				switch port.Type {
+				case intstr.Int:
+					if subsetPort.Port == port.IntVal {
+						return subsetPort, true
+					}
+				case intstr.String:
+					if subsetPort.Name == port.StrVal {
+						return subsetPort, true
+					}
+				}
+
 			}
 		}
 	}
-	return false
+	return
 }
 
 // GetSecretCert extracts the 'cert.pem' from a secret
@@ -30,18 +40,18 @@ func GetSecretCert(sec *v1.Secret) (cert []byte, exists bool) {
 	return
 }
 
-// GetServicePort extracts the port defined by a service
-func GetServicePort(svc *v1.Service, port intstr.IntOrString) (val int32, exists bool) {
+// GetServicePort extracts the matching service port
+func GetServicePort(svc *v1.Service, port intstr.IntOrString) (val v1.ServicePort, exists bool) {
 	if svc != nil {
 		for _, servicePort := range svc.Spec.Ports {
 			switch port.Type {
 			case intstr.Int:
 				if servicePort.Port == port.IntVal {
-					return servicePort.Port, true
+					return servicePort, true
 				}
 			case intstr.String:
 				if servicePort.Name == port.StrVal {
-					return servicePort.Port, true
+					return servicePort, true
 				}
 			}
 		}


### PR DESCRIPTION
As part of ingress validation prior to starting a tunnel, verify that
the service parget port matches an endpoint port (otherwise the tunnel
will launch but be of no value)