### PR TITLE
refreshing docs for 0.6.x

### DIFF
--- a/deploy/argo-tunnel-no-rbac.yaml
+++ b/deploy/argo-tunnel-no-rbac.yaml
@@ -27,8 +27,7 @@ spec:
         args:
         - --incluster
         - --ingress-class=argo-tunnel
-        - --default-origin-secret=$(POD_NAMESPACE)/anydomain
-        - --v=2
+        - --v=3
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/deploy/argo-tunnel.yaml
+++ b/deploy/argo-tunnel.yaml
@@ -15,6 +15,7 @@ rules:
   resources:
   - ingresses
   - services
+  - secrets
   - endpoints
   verbs:
   - list
@@ -28,32 +29,6 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argo-tunnel
-subjects:
-- kind: ServiceAccount
-  name: argo-tunnel
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: argo-tunnel
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: argo-tunnel
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
   name: argo-tunnel
 subjects:
 - kind: ServiceAccount
@@ -89,8 +64,7 @@ spec:
         args:
         - --incluster
         - --ingress-class=argo-tunnel
-        - --default-origin-secret=$(POD_NAMESPACE)/anydomain
-        - --v=2
+        - --v=3
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -20,10 +20,12 @@
 - `argo.cloudflare.com/lb-pool`: attach a Cloudflare loadbalancer for high-availability
   - load-balancing must be enabled for the Cloudflare account
   - allows balancing traffic across clusters
+  - **required** if replicas > 1
 - `argo.cloudflare.com/no-chunked-encoding`: disables chunked transfer encoding; useful if you are running a WSGI server
   - defaults to `"false"`
 - `argo.cloudflare.com/retries`: maximum number of retries for connection/protocol errors.
-  - defaults to `"5"`
+  - defaults to `"3"`
 
-### Secret Labels
-- `cloudflare-argo/domain`: the label is required to pair a secret with a domain
+### Command-Line Options
+- `--default-origin-secret`: the default certificate used to establish tunnels
+  - any tunnel that does not specify a secret will use this default.

--- a/docs/guide_first_tunnel.md
+++ b/docs/guide_first_tunnel.md
@@ -29,15 +29,15 @@ zone credentials.
 [Follow these instructions to install cloudflared][argo-tunnel-daemon]
 
 Once installed, verify cloudflared has installed properly by checking the version.
-```bash
+```console
 cloudflared --version
 ```
 
 ### Step 3: Login to your Cloudflare account
-```bash
+```console
 cloudflared login
 ```
-_If the browser fails to open automatically, copy and paste the URL into your 
+> _If the browser fails to open automatically, copy and paste the URL into your 
 browser’s address bar and press enter._
 
 Once you login, you will see a list of domains associated with your account.
@@ -47,45 +47,35 @@ which will be downloaded automatically by your browser. This certificate will
 be used to authenticate your machine to the Cloudflare edge.
 
 Move the certificate to the ```.cloudflared``` directory on your system.
-```bash
+```console
 mv cert.pem ~/.cloudflared/cert.pem
 ```
 
 The certificate and domain will be used to define an Ingress to your system.
 
 ### Step 4: Deploy a Tunnel Secret
-```bash
+```console
 kubectl create secret generic mydomain.com --from-file="$HOME/.cloudflared/cert.pem"
-kubectl label secret mydomain.com "cloudflare-argo/domain=mydomain.com"
 ```
-> Create the secret in the same namespace as the controller deployment.
+> Create the secret in the **same namespace** as your service deployment.
 > Adjust `mydomain.com` to match your Cloudflare domain.
 
-A single controller can configure tunnels for multiple domains.
-
-**Caveats**:
-- the secret is paired to a domain using the label `cloudflare-argo/domain`
-- the secret must be co-located with the ingress controller deployment (e.g. deployed to the same namespace)
-
-> These caveats will be addressed in future releases.
+A single controller can configure tunnels for multiple domains. An [Ingress][kubernetes-ingress] definition will be used to defined tunnels to Services and link Secrets by external hostname.
 
 ### Step 5: Attach a Tunnel
-When the controller observes the creation of an ingress, it verifies that
+When the controller observes the creation of an [Ingress][kubernetes-ingress], it verifies that
 the referenced service, endpoints, and secret exists and opens a tunnel
 between the Cloudflare receiver and the kubernetes virtual service ip.
 
-```bash
+```console
 kubectl apply -f deploy/echo.yaml
 ```
 > Adjust the Ingress host `echo.mydomain.com` to match your Cloudflare domain.
 
 **Caveats**:
-- an Ingress is restricted to a single rule (`Ingress.spec.rules[0]`)
-- a rule is restricted to a single path (`Ingress.spec.rules[0].host.http.paths[0]`)
-- tls on the Ingress is not support (`Ingress.spec.tls`)
-- routing by path is not supported (`Ingress.spec.rules[0].host.http.paths[0].path`)
+- routing by path is not supported (`Ingress.spec.rules[*].host.http.paths[*].path`)
 
-> These caveats will be addressed in future releases.
+> This caveat will be addressed in future releases.
 
 ### Step 6: Verify the Tunnel
 The tunnel will be visible under [DNS][cloudflare-dashboard-dns] on the Cloudflare dashboard.
@@ -100,3 +90,4 @@ The tunnel will be visible under [DNS][cloudflare-dashboard-dns] on the Cloudfla
 [cloudflare-dashboard-traffic]: https://www.cloudflare.com/a/traffic/
 [cloudflare-login]: http://cloudflare.com/a/login
 [cloudflare-quick-start-step-2]: https://support.cloudflare.com/hc/en-us/articles/201720164-Step-2-Create-a-Cloudflare-account-and-add-a-websit
+[kubernetes-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/docs/guide_ha_tunnel.md
+++ b/docs/guide_ha_tunnel.md
@@ -23,7 +23,7 @@ at [Argo Tunnel: Load-Balancing][cloudflare-reference-load-balancing]
 
 ### Step 2: Annotate the Ingress
 Add the annotation `argo.cloudflare.com/lb-pool=echo-lb-pool` the `echo` Ingress.
-```bash
+```console
 kubectl annotate ing echo "argo.cloudflare.com/lb-pool=echo-lb-pool"
 ```
 

--- a/docs/guide_subdomain_tunnel.md
+++ b/docs/guide_subdomain_tunnel.md
@@ -29,9 +29,8 @@ awk '/BEGIN.*TUNNEL/{mark=1}/END.*TUNNEL/{print;mark=0}mark' ~/.cloudflared/cert
 ### Step 3: Deploy the Tunnel Secret
 ```bash
 kubectl create secret generic subdomain.mydomain.com --from-file="cert.pem"
-kubectl label secret subdomain.mydomain.com "cloudflare-argo/domain=subdomain.mydomain.com"
 ```
-> Create the secret in the same namespace as the controller deployment.
+> Create the secret in the same namespace as the service deployment.
 > Adjust `subdomain.mydomain.com` to match your Cloudflare domain.
 
 ### Step 4: Attach a Tunnel


### PR DESCRIPTION
The refresh largely removes caveats sections as the updated resource
handling for 0.6.x removes restrictions of both ingresses and secrets.