### PR TITLE
Remove unused tunnel opts

### DIFF
--- a/internal/argotunnel/translator.go
+++ b/internal/argotunnel/translator.go
@@ -241,7 +241,6 @@ func (t *syncTranslator) getRouteFromIngress(ing *v1beta1.Ingress) (r *tunnelRou
 	r = &tunnelRoute{
 		name:      ing.Name,
 		namespace: ing.Namespace,
-		options:   opts,
 		links:     linkmap,
 	}
 	return

--- a/internal/argotunnel/translator_test.go
+++ b/internal/argotunnel/translator_test.go
@@ -152,7 +152,6 @@ func TestGetRouteFromIngress(t *testing.T) {
 			out: &tunnelRoute{
 				name:      "unit",
 				namespace: "unit",
-				options:   collectTunnelOptions(parseIngressTunnelOptions(&v1beta1.Ingress{})),
 				links:     tunnelRouteLinkMap{},
 			},
 		},
@@ -258,7 +257,6 @@ func TestGetRouteFromIngress(t *testing.T) {
 			out: &tunnelRoute{
 				name:      "unit",
 				namespace: "unit",
-				options:   collectTunnelOptions(parseIngressTunnelOptions(&v1beta1.Ingress{})),
 				links: tunnelRouteLinkMap{
 					tunnelRule{
 						host: "a.unit.com",

--- a/internal/argotunnel/tunnel.go
+++ b/internal/argotunnel/tunnel.go
@@ -29,7 +29,6 @@ const (
 type tunnelRoute struct {
 	name      string
 	namespace string
-	options   tunnelOptions
 	links     tunnelRouteLinkMap
 }
 


### PR DESCRIPTION
All links in a route contain the same tunnel options.  The top-level
structure only needs to maintain the struct if the underlying strcture
does not; however, links currently maintain options leaving this field
unused.