### PR TITLE
upgrade to go 1.10.6 to resolve security issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.5 AS build
+FROM golang:1.10.6 AS build
 WORKDIR /go/src/github.com/cloudflare/cloudflare-ingress-controller
 
 ARG VERSION="unknown"

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.5 AS build
+FROM golang:1.10.6 AS build
 WORKDIR /go/src/github.com/cloudflare/cloudflare-ingress-controller
 
 RUN go get github.com/golang/dep/cmd/dep


### PR DESCRIPTION
Migrate to 1.10.6 to resolve security issue with crypto/x509, cpu
denial of service in chain validation. The issue is CVE-2018-16875
and Go issue golang.org/issue/29233