### PR TITLE
adds origin-secret-config mapping file

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -29,3 +29,8 @@
 ### Command-Line Options
 - `--default-origin-secret`: the default certificate used to establish tunnels
   - any tunnel that does not specify a secret will use this default.
+- `--origin-secret-config`: the default certificate used for specific hosts
+  - any matching host that does not specify a secret will use this default.
+  - see [origin-secret-config][guide-origin-secret-config]
+
+[guide-origin-secret-config]: ./guide_origin_secret_config.md

--- a/docs/guide_origin_secret_config.md
+++ b/docs/guide_origin_secret_config.md
@@ -1,0 +1,32 @@
+# Origin Secret Configuration
+Tunnel secret handling more closely follows the [Ingress][kubernetes-ingress] definition,
+reusing the `TLS` section to map hosts to tunnel secrets. The revised handling restricts
+tunnel secrets to be collocated with the [Ingress][kubernetes-ingress], a restriction not
+present in previous versions.
+
+To help with migration and to allow a set of reusable secrets to be located in an isolated
+namepace, a configuration has been introduced to provide host specific default secrets.
+
+The control `--origin-secret-config` sets the file path to origin specific secret
+configuration.
+
+### Format
+The configuration is Yaml
+```yaml
+groups:
+- hosts:
+  - abc.test.com
+  - cba.test.com
+  secret:
+    name: test-a
+    namespace: test-a
+- hosts:
+  - xyz.test.com
+  - zyx.test.com
+  secret:
+    name: test-b
+    namespace: test-b
+```
+> * wildcard hosts are not allowed
+
+[kubernetes-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/internal/argotunnel/informer.go
+++ b/internal/argotunnel/informer.go
@@ -58,7 +58,7 @@ func newEndpointInformer(client kubernetes.Interface, opts options, rs ...cache.
 func newIngressInformer(client kubernetes.Interface, opts options, rs ...cache.ResourceEventHandler) cache.SharedIndexInformer {
 	i := newInformer(client.ExtensionsV1beta1().RESTClient(), opts.watchNamespace, "ingresses", new(v1beta1.Ingress), opts.resyncPeriod, rs...)
 	i.AddIndexers(cache.Indexers{
-		secretKind:  ingressSecretIndexFunc(opts.ingressClass, opts.secret),
+		secretKind:  ingressSecretIndexFunc(opts.ingressClass, opts.originSecrets, opts.secret),
 		serviceKind: ingressServiceIndexFunc(opts.ingressClass),
 	})
 	return i
@@ -83,7 +83,7 @@ func newInformer(c cache.Getter, namespace string, resource string, objType runt
 	return sw
 }
 
-func ingressSecretIndexFunc(ingressClass string, secret *resource) func(obj interface{}) ([]string, error) {
+func ingressSecretIndexFunc(ingressClass string, originSecrets map[string]*resource, secret *resource) func(obj interface{}) ([]string, error) {
 	return func(obj interface{}) ([]string, error) {
 		if ing, ok := obj.(*v1beta1.Ingress); ok {
 			var idx []string
@@ -102,6 +102,8 @@ func ingressSecretIndexFunc(ingressClass string, secret *resource) func(obj inte
 				for _, rule := range ing.Spec.Rules {
 					if rule.HTTP != nil && len(rule.Host) > 0 {
 						if r, ok := hostsecret[rule.Host]; ok {
+							idx = append(idx, itemKeyFunc(r.namespace, r.name))
+						} else if r, ok := originSecrets[rule.Host]; ok {
 							idx = append(idx, itemKeyFunc(r.namespace, r.name))
 						} else if secret != nil {
 							idx = append(idx, itemKeyFunc(secret.namespace, secret.name))

--- a/internal/argotunnel/informer_test.go
+++ b/internal/argotunnel/informer_test.go
@@ -139,7 +139,7 @@ func TestIngressSecretIndexFunc(t *testing.T) {
 			err: nil,
 		},
 	} {
-		indexFunc := ingressSecretIndexFunc("unit", nil)
+		indexFunc := ingressSecretIndexFunc("unit", nil, nil)
 		out, err := indexFunc(test.obj)
 		assert.Equalf(t, test.out, out, "test '%s' index mismatch", name)
 		assert.Equalf(t, test.err, err, "test '%s' error mismatch", name)

--- a/internal/argotunnel/options_test.go
+++ b/internal/argotunnel/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudflare/cloudflare-ingress-controller/internal/cloudflare"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,14 +40,32 @@ func TestOptions(t *testing.T) {
 				ResyncPeriod(1 * time.Minute),
 				RequeueLimit(-1),
 				Secret("test-secret-name", "test-secret-namespace"),
+				SecretGroups(cloudflare.OriginSecrets{
+					Groups: []cloudflare.OriginSecretGroup{
+						{
+							Hosts: []string{
+								"abc.test.com",
+								"xyz.test.com",
+							},
+							Secret: cloudflare.OriginSecret{
+								Name:      "test-secret-name",
+								Namespace: "test-secret-namespace",
+							},
+						},
+					},
+				}),
 				WatchNamespace("test-watch-namespace"),
 				Workers(2),
 			},
 			out: options{
-				ingressClass:   "test-class",
-				resyncPeriod:   1 * time.Minute,
-				requeueLimit:   -1,
-				secret:         &resource{"test-secret-name", "test-secret-namespace"},
+				ingressClass: "test-class",
+				resyncPeriod: 1 * time.Minute,
+				requeueLimit: -1,
+				secret:       &resource{"test-secret-name", "test-secret-namespace"},
+				originSecrets: map[string]*resource{
+					"abc.test.com": {"test-secret-name", "test-secret-namespace"},
+					"xyz.test.com": {"test-secret-name", "test-secret-namespace"},
+				},
 				watchNamespace: "test-watch-namespace",
 				workers:        2,
 			},

--- a/internal/argotunnel/translator.go
+++ b/internal/argotunnel/translator.go
@@ -185,6 +185,8 @@ func (t *syncTranslator) getRouteFromIngress(ing *v1beta1.Ingress) (r *tunnelRou
 		secret := func() *resource {
 			if r, ok := hostsecret[rule.Host]; ok {
 				return r
+			} else if r, ok := t.options.originSecrets[rule.Host]; ok {
+				return r
 			} else if t.options.secret != nil {
 				return t.options.secret
 			}

--- a/internal/cloudflare/originsecret.go
+++ b/internal/cloudflare/originsecret.go
@@ -1,0 +1,126 @@
+package cloudflare
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+type multierror struct {
+	causes []error
+	detail string
+}
+
+// Error collapses the MultiError into a string
+func (e *multierror) Error() string {
+	if e.detail == "" {
+		var a = make([]string, len(e.causes))
+		for i := 0; i < len(e.causes); i++ {
+			a[i] = e.causes[i].Error()
+		}
+		e.detail = strings.Join(a, ", ")
+	}
+	return e.detail
+}
+
+// ParseOriginSecrets parses a origin certificate mapping
+func ParseOriginSecrets(b []byte) (*OriginSecrets, error) {
+	var oc OriginSecrets
+	if err := yaml.UnmarshalStrict(b, &oc); err != nil {
+		return nil, err
+	}
+	if errs := oc.Validate(); len(errs) > 0 {
+		return nil, &multierror{
+			causes: oc.Validate(),
+		}
+	}
+	return &oc, nil
+}
+
+// ParseOriginSecretsFile parses a origin certificate mapping file
+func ParseOriginSecretsFile(file string) (oc *OriginSecrets, err error) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return
+	}
+	return ParseOriginSecrets(b)
+}
+
+// OriginSecrets is a mapping of origins to secrets
+type OriginSecrets struct {
+	Groups []OriginSecretGroup `yaml:"groups"`
+}
+
+// Validate the OriginCerts content
+func (oc *OriginSecrets) Validate() []error {
+	var errs []error
+	for i, group := range oc.Groups {
+		if es := group.Validate(); len(es) > 0 {
+			for _, e := range es {
+				errs = append(errs, fmt.Errorf("group at index %d, %s", i, e.Error()))
+			}
+		}
+	}
+	return errs
+}
+
+// OriginSecretGroup groups a set of origins to a secret
+type OriginSecretGroup struct {
+	Hosts  []string     `yaml:"hosts"`
+	Secret OriginSecret `yaml:"secret"`
+}
+
+// Validate the OriginSecretGroup content
+func (ocg *OriginSecretGroup) Validate() []error {
+	var errs []error
+	if len(ocg.Hosts) == 0 {
+		errs = append(errs, fmt.Errorf("hosts %s", validation.EmptyError()))
+	} else {
+		for i, host := range ocg.Hosts {
+			if len(host) == 0 {
+				errs = append(errs, fmt.Errorf("host at index %d %s", i, validation.EmptyError()))
+			} else if strings.Contains(host, "*") {
+				errs = append(errs, fmt.Errorf("host %q at index %d must not contain '*'", host, i))
+			} else {
+				for _, msg := range validation.IsDNS1123Subdomain(host) {
+					errs = append(errs, fmt.Errorf("host %q at index %d %s", host, i, msg))
+				}
+			}
+		}
+	}
+	for _, e := range ocg.Secret.Validate() {
+		errs = append(errs, fmt.Errorf("secret %s", e.Error()))
+	}
+	return errs
+}
+
+// OriginSecret defines a secret
+type OriginSecret struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
+// Validate the OriginSecret content
+func (os *OriginSecret) Validate() []error {
+	var errs []error
+	if len(os.Name) == 0 {
+		errs = append(errs, fmt.Errorf("name %s", validation.EmptyError()))
+	} else if strings.Contains(os.Name, "/") {
+		errs = append(errs, fmt.Errorf("name %q must not contain '/'", os.Name))
+	} else {
+		for _, msg := range validation.IsQualifiedName(os.Name) {
+			errs = append(errs, fmt.Errorf("name %q %s", os.Name, msg))
+		}
+	}
+	if len(os.Namespace) == 0 {
+		errs = append(errs, fmt.Errorf("namespace %s", validation.EmptyError()))
+	} else {
+		for _, msg := range validation.IsDNS1123Subdomain(os.Namespace) {
+			errs = append(errs, fmt.Errorf("namespace %q %s", os.Namespace, msg))
+		}
+	}
+	return errs
+}

--- a/internal/cloudflare/originsecret_test.go
+++ b/internal/cloudflare/originsecret_test.go
@@ -1,0 +1,299 @@
+package cloudflare
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type unitfile struct {
+	name string
+	data []byte
+	mode os.FileMode
+}
+
+func TestOriginSecrets(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  *OriginSecrets
+		err []error
+	}{
+		"obj-empty": {
+			in:  &OriginSecrets{},
+			err: nil,
+		},
+		"obj-empty-in-group": {
+			in: &OriginSecrets{
+				Groups: []OriginSecretGroup{
+					{
+						Hosts: []string{},
+					},
+				},
+			},
+			err: []error{
+				fmt.Errorf("group at index 0, hosts must be non-empty"),
+				fmt.Errorf("group at index 0, secret name must be non-empty"),
+				fmt.Errorf("group at index 0, secret namespace must be non-empty"),
+			},
+		},
+		"obj-bad-hosts-in-group": {
+			in: &OriginSecrets{
+				Groups: []OriginSecretGroup{
+					{
+						Hosts: []string{
+							"",
+							"*.test.com",
+							"#@!.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			err: []error{
+				fmt.Errorf("group at index 0, host at index 0 must be non-empty"),
+				fmt.Errorf(`group at index 0, host "*.test.com" at index 1 must not contain '*'`),
+				fmt.Errorf(`group at index 0, host "#@!.test.com" at index 2 a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`),
+			},
+		},
+		"obj-bad-secret-name-in-group": {
+			in: &OriginSecrets{
+				Groups: []OriginSecretGroup{
+					{
+						Hosts: []string{
+							"0.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "",
+							Namespace: "test",
+						},
+					},
+					{
+						Hosts: []string{
+							"1.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "unit/test",
+							Namespace: "test",
+						},
+					},
+					{
+						Hosts: []string{
+							"2.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "@test@",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			err: []error{
+				fmt.Errorf("group at index 0, secret name must be non-empty"),
+				fmt.Errorf(`group at index 1, secret name "unit/test" must not contain '/'`),
+				fmt.Errorf(`group at index 2, secret name "@test@" name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`),
+			},
+		},
+		"obj-bad-secret-namespace-in-group": {
+			in: &OriginSecrets{
+				Groups: []OriginSecretGroup{
+					{
+						Hosts: []string{
+							"0.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test",
+							Namespace: "",
+						},
+					},
+					{
+						Hosts: []string{
+							"1.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test",
+							Namespace: "@test@",
+						},
+					},
+				},
+			},
+			err: []error{
+				fmt.Errorf("group at index 0, secret namespace must be non-empty"),
+				fmt.Errorf(`group at index 1, secret namespace "@test@" a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`),
+			},
+		},
+		"obj-okay": {
+			in: &OriginSecrets{
+				Groups: []OriginSecretGroup{
+					{
+						Hosts: []string{
+							"abc.test.com",
+							"xyz.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+	} {
+		err := test.in.Validate()
+		assert.Equalf(t, test.err, err, "test '%s' err mismatch", name)
+	}
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		in  string
+		out *OriginSecrets
+		err error
+	}{
+		"obj-empty": {
+			in:  "",
+			out: &OriginSecrets{},
+			err: nil,
+		},
+		"obj-parse-error": {
+			in:  errorCerts,
+			out: nil,
+			err: fmt.Errorf(`group at index 1, host "*.test.com" at index 0 must not contain '*'`),
+		},
+		"obj-parse-okay": {
+			in: okayCerts,
+			out: &OriginSecrets{
+				Groups: []OriginSecretGroup{
+					{
+						Hosts: []string{
+							"abc.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test-a",
+							Namespace: "test-a",
+						},
+					},
+					{
+						Hosts: []string{
+							"xyz.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test-b",
+							Namespace: "test-b",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+	} {
+		out, err := ParseOriginSecrets([]byte(test.in))
+		if err != nil {
+			err = fmt.Errorf("%s", err.Error())
+		}
+		assert.Equalf(t, test.out, out, "test '%s' val mismatch", name)
+		assert.Equalf(t, test.err, err, "test '%s' err mismatch", name)
+	}
+}
+
+func TestParseFile(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		file unitfile
+		mode os.FileMode
+		out  *OriginSecrets
+		err  error
+	}{
+		"obj-parse-empty": {
+			file: unitfile{name: "test.yaml", data: []byte(""), mode: 0644},
+			mode: 0700,
+			out:  &OriginSecrets{},
+			err:  nil,
+		},
+		"obj-parse-error": {
+			file: unitfile{name: "test.yaml", data: []byte(errorCerts), mode: 0644},
+			mode: 0700,
+			out:  nil,
+			err:  fmt.Errorf(`group at index 1, host "*.test.com" at index 0 must not contain '*'`),
+		},
+		"obj-parse-okay": {
+			file: unitfile{name: "test.yaml", data: []byte(okayCerts), mode: 0644},
+			mode: 0700,
+			out: &OriginSecrets{
+				Groups: []OriginSecretGroup{
+					{
+						Hosts: []string{
+							"abc.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test-a",
+							Namespace: "test-a",
+						},
+					},
+					{
+						Hosts: []string{
+							"xyz.test.com",
+						},
+						Secret: OriginSecret{
+							Name:      "test-b",
+							Namespace: "test-b",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+	} {
+		rootdir, err := ioutil.TempDir("", "root-")
+		assert.NoError(t, err, "must not error creating rootdir")
+		defer os.RemoveAll(rootdir)
+
+		filepath := filepath.Join(rootdir, test.file.name)
+		ioutil.WriteFile(filepath, test.file.data, 0644)
+		os.Chmod(filepath, test.file.mode)
+		os.Chmod(rootdir, test.mode)
+
+		out, err := ParseOriginSecretsFile(filepath)
+		if err != nil {
+			err = fmt.Errorf("%s", err.Error())
+		}
+		assert.Equalf(t, test.out, out, "test '%s' val mismatch", name)
+		assert.Equalf(t, test.err, err, "test '%s' err mismatch", name)
+	}
+}
+
+const okayCerts = `
+groups:
+- hosts:
+  - abc.test.com
+  secret:
+    name: test-a
+    namespace: test-a
+- hosts:
+  - xyz.test.com
+  secret:
+    name: test-b
+    namespace: test-b
+`
+
+const errorCerts = `
+groups:
+- hosts:
+  - abc.test.com
+  secret:
+    name: test-a
+    namespace: test-a
+- hosts:
+  - "*.test.com"
+  secret:
+    name: test-b
+    namespace: test-b
+`


### PR DESCRIPTION
Adds the command-line flag `--origin-secret-config`, allowing
specification of a host specific default secret mapping file.  The
additional configuration is meant to help with migration from 0.5.x to
0.6.x and allows isolation of reuseable secrets.

Resolves #126 