### PR TITLE
issues-139: incorrect server to subset port match

### DIFF
--- a/internal/argotunnel/translator.go
+++ b/internal/argotunnel/translator.go
@@ -307,9 +307,9 @@ func (t *syncTranslator) getVerifiedPort(namespace, name string, port intstr.Int
 		return
 	}
 
-	_, exists = k8s.GetEndpointsPort(obj.(*v1.Endpoints), svcport.TargetPort, v1.ProtocolTCP)
+	exists = k8s.HasEndpointsAddresses(obj.(*v1.Endpoints))
 	if !exists {
-		err = fmt.Errorf("endpoints '%s' missing subsets for port '%s'", key, svcport.TargetPort.String())
+		err = fmt.Errorf("endpoints '%s' missing subsets for port '%s'", key, port.String())
 		return
 	}
 

--- a/internal/argotunnel/translator_test.go
+++ b/internal/argotunnel/translator_test.go
@@ -366,11 +366,10 @@ func TestGetRouteFromIngress(t *testing.T) {
 							idx.On("GetByKey", "unit/svc-a").Return(&v1.Endpoints{
 								Subsets: []v1.EndpointSubset{
 									{
-										Ports: []v1.EndpointPort{
+										Addresses: []v1.EndpointAddress{
 											{
-												Name:     "http",
-												Port:     9090,
-												Protocol: v1.ProtocolTCP,
+												IP:       "1.1.1.1",
+												Hostname: "unit.com",
 											},
 										},
 									},
@@ -853,11 +852,10 @@ func TestGetVerifiedPort(t *testing.T) {
 							idx.On("GetByKey", "unit/svc-a").Return(&v1.Endpoints{
 								Subsets: []v1.EndpointSubset{
 									{
-										Ports: []v1.EndpointPort{
+										Addresses: []v1.EndpointAddress{
 											{
-												Name:     "port-a",
-												Port:     9090,
-												Protocol: v1.ProtocolTCP,
+												IP:       "1.1.1.1",
+												Hostname: "unit.com",
 											},
 										},
 									},

--- a/internal/k8s/audit.go
+++ b/internal/k8s/audit.go
@@ -10,6 +10,18 @@ const (
 	CertPem = "cert.pem"
 )
 
+// HasEndpointsAddresses verifies addresses are available
+func HasEndpointsAddresses(ep *v1.Endpoints) (exists bool) {
+	if ep != nil {
+		for _, subset := range ep.Subsets {
+			if len(subset.Addresses) > 0 {
+				return true
+			}
+		}
+	}
+	return
+}
+
 // GetEndpointsPort extracts the matching endpoints port
 func GetEndpointsPort(ep *v1.Endpoints, port intstr.IntOrString, protocol v1.Protocol) (val v1.EndpointPort, exists bool) {
 	if ep != nil {


### PR DESCRIPTION
It is sufficient to verify existience of ready addresses without
attempting to match ports.

resolves #139