### PR TITLE
issue-145: allow protocol logging to be enabled

### DIFF
--- a/cmd/argot/main.go
+++ b/cmd/argot/main.go
@@ -51,6 +51,7 @@ func main() {
 	debugenable := couple.Flag("debug-enable", "enable profiling handler").Bool()
 	metricsaddr := couple.Flag("metrics-address", "metrics bind address").Default("0.0.0.0:8080").String()
 	metricsenable := couple.Flag("metrics-enable", "enable metrics handler").Bool()
+	protologenable := couple.Flag("proto-log-enable", "enable protocol logging").Bool()
 	connlimit := couple.Flag("connection-limit", "profiling bind address").Default("512").Int()
 	resyncperiod := couple.Flag("resync-period", "period between synchronization attempts").Default(argotunnel.ResyncPeriodDefault.String()).Duration()
 	watchNamespace := couple.Flag("watch-namespace", "restrict resource watches to namespace").Default(v1.NamespaceAll).String()
@@ -72,6 +73,12 @@ func main() {
 		log := logrus.StandardLogger()
 		log.SetLevel(logruslevel(*verbose))
 		log.Out = os.Stderr
+
+		if *protologenable {
+			protolog := argotunnel.ProtoLogger()
+			protolog.SetLevel(logruslevel(*verbose))
+			protolog.Out = os.Stderr
+		}
 
 		var g run.Group
 		{

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -32,6 +32,9 @@
 - `--origin-secret-config`: the default certificate used for specific hosts
   - any matching host that does not specify a secret will use this default.
   - see [origin-secret-config][guide-origin-secret-config]
+- `--proto-log-enable`: enable tunnel protocol logging
+- `--v`: set the controller log level
+  - defaults to `"3"`
 - `--watch-namespace`: restrict resource watches to a namespace
 
 [guide-origin-secret-config]: ./guide_origin_secret_config.md

--- a/internal/argotunnel/protologger.go
+++ b/internal/argotunnel/protologger.go
@@ -1,0 +1,52 @@
+package argotunnel
+
+import (
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Setting Formatter and Out is not thread-safe; Level and Hooks
+// use the loggers internal mechanism (e.g. only change Formatter
+// and Out in main prior to threaded execution).
+
+var (
+	// protoLogger is the name of the proto logger
+	protoLogger = func() *logrus.Logger {
+		log := logrus.New()
+		log.SetLevel(logrus.PanicLevel)
+		log.Out = os.Stderr
+		return log
+	}()
+)
+
+// ProtoLogger returns the proto logger
+func ProtoLogger() *logrus.Logger {
+	return protoLogger
+}
+
+// SetOutput sets the standard logger output.
+func SetOutput(out io.Writer) {
+	protoLogger.Out = out
+}
+
+// SetFormatter sets the standard logger formatter.
+func SetFormatter(formatter logrus.Formatter) {
+	protoLogger.Formatter = formatter
+}
+
+// SetLevel sets the standard logger level.
+func SetLevel(level logrus.Level) {
+	protoLogger.SetLevel(level)
+}
+
+// GetLevel returns the standard logger level.
+func GetLevel() logrus.Level {
+	return protoLogger.Level
+}
+
+// AddHook adds a hook to the standard logger hooks.
+func AddHook(hook logrus.Hook) {
+	protoLogger.Hooks.Add(hook)
+}

--- a/internal/argotunnel/tunnel.go
+++ b/internal/argotunnel/tunnel.go
@@ -176,7 +176,7 @@ func newLinkTunnelConfig(rule tunnelRule, cert []byte, options tunnelOptions) *o
 		Metrics:           metricsConfig.metrics,
 		MetricsUpdateFreq: metricsConfig.updateFrequency,
 		// todo: alter logger creation to allow easy disable for tests
-		ProtocolLogger:     logrus.New(), // new to avoid sharing log-level (very noisy)
+		ProtocolLogger:     ProtoLogger(),
 		Logger:             logrus.StandardLogger(),
 		IsAutoupdated:      false,
 		GracePeriod:        options.gracePeriod,


### PR DESCRIPTION
Adds flag `proto-log-enable`.  When enabled, the protocol logger will be
given the same log-level as the controller logger.

resolves #145