### PR TITLE
expands default secret mapping to wildcards

### DIFF
--- a/cmd/argot/main.go
+++ b/cmd/argot/main.go
@@ -183,8 +183,8 @@ func main() {
 			ctx, cancel := context.WithCancel(context.Background())
 			argo := argotunnel.NewController(kclient, log,
 				argotunnel.IngressClass(*ingressclass),
-				argotunnel.Secret(originsecret.Name, originsecret.Namespace),
 				argotunnel.SecretGroups(*secretgroups),
+				argotunnel.Secret(originsecret.Name, originsecret.Namespace),
 				argotunnel.ResyncPeriod(*resyncperiod),
 				argotunnel.WatchNamespace(*watchNamespace),
 				argotunnel.Workers(*workers),

--- a/docs/guide_origin_secret_config.md
+++ b/docs/guide_origin_secret_config.md
@@ -26,7 +26,13 @@ groups:
   secret:
     name: test-b
     namespace: test-b
+- hosts:
+  - "*.test.com"
+  secret:
+    name: test-c
+    namespace: test-c
 ```
-> * wildcard hosts are not allowed
+> * wildcard hosts are allowed
+> * specific hosts take precedence over wildcard hosts
 
 [kubernetes-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/internal/argotunnel/options_test.go
+++ b/internal/argotunnel/options_test.go
@@ -34,6 +34,31 @@ func TestOptions(t *testing.T) {
 				workers:      WorkersDefault,
 			},
 		},
+		"set-secret-default-from-groups": {
+			in: []Option{
+				Secret("test-secret-name-a", "test-secret-namespace-a"),
+				SecretGroups(cloudflare.OriginSecrets{
+					Groups: []cloudflare.OriginSecretGroup{
+						{
+							Hosts: []string{
+								"*",
+							},
+							Secret: cloudflare.OriginSecret{
+								Name:      "test-secret-name-b",
+								Namespace: "test-secret-namespace-b",
+							},
+						},
+					},
+				}),
+			},
+			out: options{
+				ingressClass: IngressClassDefault,
+				resyncPeriod: ResyncPeriodDefault,
+				requeueLimit: RequeueLimitDefault,
+				secret:       &resource{"test-secret-name-b", "test-secret-namespace-b"},
+				workers:      WorkersDefault,
+			},
+		},
 		"set-all-options": {
 			in: []Option{
 				IngressClass("test-class"),
@@ -46,6 +71,7 @@ func TestOptions(t *testing.T) {
 							Hosts: []string{
 								"abc.test.com",
 								"xyz.test.com",
+								"*.unit.com",
 							},
 							Secret: cloudflare.OriginSecret{
 								Name:      "test-secret-name",
@@ -65,6 +91,9 @@ func TestOptions(t *testing.T) {
 				originSecrets: map[string]*resource{
 					"abc.test.com": {"test-secret-name", "test-secret-namespace"},
 					"xyz.test.com": {"test-secret-name", "test-secret-namespace"},
+				},
+				domainSecrets: map[string]*resource{
+					"unit.com": {"test-secret-name", "test-secret-namespace"},
 				},
 				watchNamespace: "test-watch-namespace",
 				workers:        2,

--- a/internal/argotunnel/translator.go
+++ b/internal/argotunnel/translator.go
@@ -187,6 +187,8 @@ func (t *syncTranslator) getRouteFromIngress(ing *v1beta1.Ingress) (r *tunnelRou
 				return r
 			} else if r, ok := t.options.originSecrets[rule.Host]; ok {
 				return r
+			} else if r, ok := getDomainSecret(rule.Host, t.options.domainSecrets); ok {
+				return r
 			} else if t.options.secret != nil {
 				return t.options.secret
 			}

--- a/internal/cloudflare/originsecret.go
+++ b/internal/cloudflare/originsecret.go
@@ -83,7 +83,11 @@ func (ocg *OriginSecretGroup) Validate() []error {
 			if len(host) == 0 {
 				errs = append(errs, fmt.Errorf("host at index %d %s", i, validation.EmptyError()))
 			} else if strings.Contains(host, "*") {
-				errs = append(errs, fmt.Errorf("host %q at index %d must not contain '*'", host, i))
+				if host != "*" {
+					for _, msg := range validation.IsWildcardDNS1123Subdomain(host) {
+						errs = append(errs, fmt.Errorf("host %q at index %d %s", host, i, msg))
+					}
+				}
 			} else {
 				for _, msg := range validation.IsDNS1123Subdomain(host) {
 					errs = append(errs, fmt.Errorf("host %q at index %d %s", host, i, msg))


### PR DESCRIPTION
Expands host definitions allowed by `origin-secret-config`. Wildcard
hosts of the form "*.domain" and "*" are now allowed. When a wildcard
conflicts with a specific host, the specific mapping takes precedence.
If both "*" and `default-origin-secret` are specified,
`default-origin-secret` takes precedence.

resolves #126